### PR TITLE
Add Stampede2 scaling results for Skylake nodes

### DIFF
--- a/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_12_2_1
+++ b/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_12_2_1
@@ -1,0 +1,100 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 2.0.0-pre (master, 7a539e8)
+--     . using deal.II 8.5.1 (v8.5.1, 0e5d7e8)
+--     . using Trilinos 12.10.1
+--     . using p4est 1.1.0
+--     . running in OPTIMIZED mode
+--     . running with 12 MPI processes
+-----------------------------------------------------------------------------
+
+Number of active cells: 6,144 (on 3 levels)
+Number of degrees of freedom: 268,220 (156,774+6,930+52,258+52,258)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+24 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.0181 m/year, 0.0426 m/year
+     Temperature min/avg/max: 1522 K, 1600 K, 1678 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      8.19s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         1 |     0.704s |       8.6% |
+| Assemble composition system     |         1 |     0.215s |       2.6% |
+| Assemble temperature system     |         1 |     0.345s |       4.2% |
+| Build Stokes preconditioner     |         1 |     0.565s |       6.9% |
+| Build composition preconditioner|         1 |    0.0342s |      0.42% |
+| Build temperature preconditioner|         1 |    0.0509s |      0.62% |
+| Solve Stokes system             |         1 |      5.13s |        63% |
+| Solve composition system        |         1 |   0.00549s |         0% |
+| Solve temperature system        |         1 |    0.0349s |      0.43% |
+| Initialization                  |         1 |     0.189s |       2.3% |
+| Postprocessing                  |         1 |    0.0447s |      0.55% |
+| Setup dof systems               |         1 |     0.251s |       3.1% |
+| Setup initial conditions        |         1 |    0.0952s |       1.2% |
++---------------------------------+-----------+------------+------------+
+
+*** Timestep 1:  t=2.2543e+06 years
+   Solving temperature system... 14 iterations.
+   Solving C_1 system ... 15 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+22 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.018 m/year, 0.0423 m/year
+     Temperature min/avg/max: 1523 K, 1600 K, 1678 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |        15s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |      1.44s |       9.6% |
+| Assemble composition system     |         2 |     0.455s |         3% |
+| Assemble temperature system     |         2 |     0.694s |       4.6% |
+| Build Stokes preconditioner     |         2 |      1.07s |       7.1% |
+| Build composition preconditioner|         2 |    0.0663s |      0.44% |
+| Build temperature preconditioner|         2 |    0.0833s |      0.55% |
+| Solve Stokes system             |         2 |      9.96s |        66% |
+| Solve composition system        |         2 |    0.0253s |      0.17% |
+| Solve temperature system        |         2 |    0.0532s |      0.35% |
+| Initialization                  |         1 |     0.189s |       1.3% |
+| Postprocessing                  |         2 |    0.0841s |      0.56% |
+| Setup dof systems               |         1 |     0.251s |       1.7% |
+| Setup initial conditions        |         1 |    0.0952s |      0.63% |
++---------------------------------+-----------+------------+------------+
+
+Termination requested by criterion: end step
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |        15s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |      1.44s |       9.6% |
+| Assemble composition system     |         2 |     0.455s |         3% |
+| Assemble temperature system     |         2 |     0.694s |       4.6% |
+| Build Stokes preconditioner     |         2 |      1.07s |       7.1% |
+| Build composition preconditioner|         2 |    0.0663s |      0.44% |
+| Build temperature preconditioner|         2 |    0.0833s |      0.55% |
+| Solve Stokes system             |         2 |      9.96s |        66% |
+| Solve composition system        |         2 |    0.0253s |      0.17% |
+| Solve temperature system        |         2 |    0.0532s |      0.35% |
+| Initialization                  |         1 |     0.189s |       1.3% |
+| Postprocessing                  |         2 |    0.0841s |      0.56% |
+| Setup dof systems               |         1 |     0.251s |       1.7% |
+| Setup initial conditions        |         1 |    0.0952s |      0.63% |
++---------------------------------+-----------+------------+------------+
+

--- a/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_12_3_1
+++ b/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_12_3_1
@@ -1,0 +1,100 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 2.0.0-pre (master, 7a539e8)
+--     . using deal.II 8.5.1 (v8.5.1, 0e5d7e8)
+--     . using Trilinos 12.10.1
+--     . using p4est 1.1.0
+--     . running in OPTIMIZED mode
+--     . running with 12 MPI processes
+-----------------------------------------------------------------------------
+
+Number of active cells: 49,152 (on 4 levels)
+Number of degrees of freedom: 2,080,108 (1,216,710+52,258+405,570+405,570)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+26 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.0181 m/year, 0.0356 m/year
+     Temperature min/avg/max: 1521 K, 1600 K, 1679 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      65.3s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         1 |      5.39s |       8.2% |
+| Assemble composition system     |         1 |      1.53s |       2.3% |
+| Assemble temperature system     |         1 |      2.39s |       3.7% |
+| Build Stokes preconditioner     |         1 |      3.96s |       6.1% |
+| Build composition preconditioner|         1 |     0.272s |      0.42% |
+| Build temperature preconditioner|         1 |     0.295s |      0.45% |
+| Solve Stokes system             |         1 |      47.1s |        72% |
+| Solve composition system        |         1 |    0.0336s |         0% |
+| Solve temperature system        |         1 |    0.0625s |         0% |
+| Initialization                  |         1 |     0.207s |      0.32% |
+| Postprocessing                  |         1 |     0.285s |      0.44% |
+| Setup dof systems               |         1 |     0.645s |      0.99% |
+| Setup initial conditions        |         1 |     0.413s |      0.63% |
++---------------------------------+-----------+------------+------------+
+
+*** Timestep 1:  t=1.72969e+06 years
+   Solving temperature system... 14 iterations.
+   Solving C_1 system ... 15 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+24 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.018 m/year, 0.0355 m/year
+     Temperature min/avg/max: 1522 K, 1600 K, 1678 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |       156s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |      10.9s |         7% |
+| Assemble composition system     |         2 |      3.31s |       2.1% |
+| Assemble temperature system     |         2 |         5s |       3.2% |
+| Build Stokes preconditioner     |         2 |      8.03s |       5.1% |
+| Build composition preconditioner|         2 |     0.538s |      0.34% |
+| Build temperature preconditioner|         2 |     0.567s |      0.36% |
+| Solve Stokes system             |         2 |       123s |        79% |
+| Solve composition system        |         2 |     0.179s |      0.11% |
+| Solve temperature system        |         2 |     0.199s |      0.13% |
+| Initialization                  |         1 |     0.207s |      0.13% |
+| Postprocessing                  |         2 |     0.565s |      0.36% |
+| Setup dof systems               |         1 |     0.645s |      0.41% |
+| Setup initial conditions        |         1 |     0.413s |      0.26% |
++---------------------------------+-----------+------------+------------+
+
+Termination requested by criterion: end step
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |       156s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |      10.9s |         7% |
+| Assemble composition system     |         2 |      3.31s |       2.1% |
+| Assemble temperature system     |         2 |         5s |       3.2% |
+| Build Stokes preconditioner     |         2 |      8.03s |       5.1% |
+| Build composition preconditioner|         2 |     0.538s |      0.34% |
+| Build temperature preconditioner|         2 |     0.567s |      0.36% |
+| Solve Stokes system             |         2 |       123s |        79% |
+| Solve composition system        |         2 |     0.179s |      0.11% |
+| Solve temperature system        |         2 |     0.199s |      0.13% |
+| Initialization                  |         1 |     0.207s |      0.13% |
+| Postprocessing                  |         2 |     0.565s |      0.36% |
+| Setup dof systems               |         1 |     0.645s |      0.41% |
+| Setup initial conditions        |         1 |     0.413s |      0.26% |
++---------------------------------+-----------+------------+------------+
+

--- a/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_12_4_1
+++ b/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_12_4_1
@@ -1,0 +1,100 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 2.0.0-pre (master, 7a539e8)
+--     . using deal.II 8.5.1 (v8.5.1, 0e5d7e8)
+--     . using Trilinos 12.10.1
+--     . using p4est 1.1.0
+--     . running in OPTIMIZED mode
+--     . running with 12 MPI processes
+-----------------------------------------------------------------------------
+
+Number of active cells: 393,216 (on 5 levels)
+Number of degrees of freedom: 16,380,620 (9,585,030+405,570+3,195,010+3,195,010)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+13 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.0181 m/year, 0.0353 m/year
+     Temperature min/avg/max: 1521 K, 1600 K, 1679 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |       271s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         1 |      40.6s |        15% |
+| Assemble composition system     |         1 |      11.1s |       4.1% |
+| Assemble temperature system     |         1 |      18.1s |       6.7% |
+| Build Stokes preconditioner     |         1 |      25.7s |       9.5% |
+| Build composition preconditioner|         1 |      2.23s |      0.82% |
+| Build temperature preconditioner|         1 |      2.24s |      0.82% |
+| Solve Stokes system             |         1 |       144s |        53% |
+| Solve composition system        |         1 |     0.224s |         0% |
+| Solve temperature system        |         1 |     0.253s |         0% |
+| Initialization                  |         1 |       0.2s |         0% |
+| Postprocessing                  |         1 |      2.18s |       0.8% |
+| Setup dof systems               |         1 |      3.18s |       1.2% |
+| Setup initial conditions        |         1 |      2.59s |      0.96% |
++---------------------------------+-----------+------------+------------+
+
+*** Timestep 1:  t=895972 years
+   Solving temperature system... 13 iterations.
+   Solving C_1 system ... 14 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+26 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.0181 m/year, 0.0354 m/year
+     Temperature min/avg/max: 1521 K, 1600 K, 1679 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |       858s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |      86.5s |        10% |
+| Assemble composition system     |         2 |      25.7s |         3% |
+| Assemble temperature system     |         2 |      38.1s |       4.4% |
+| Build Stokes preconditioner     |         2 |      53.3s |       6.2% |
+| Build composition preconditioner|         2 |      4.59s |      0.53% |
+| Build temperature preconditioner|         2 |      4.75s |      0.55% |
+| Solve Stokes system             |         2 |       612s |        71% |
+| Solve composition system        |         2 |      1.34s |      0.16% |
+| Solve temperature system        |         2 |       1.4s |      0.16% |
+| Initialization                  |         1 |       0.2s |         0% |
+| Postprocessing                  |         2 |      4.33s |       0.5% |
+| Setup dof systems               |         1 |      3.18s |      0.37% |
+| Setup initial conditions        |         1 |      2.59s |       0.3% |
++---------------------------------+-----------+------------+------------+
+
+Termination requested by criterion: end step
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |       858s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |      86.5s |        10% |
+| Assemble composition system     |         2 |      25.7s |         3% |
+| Assemble temperature system     |         2 |      38.1s |       4.4% |
+| Build Stokes preconditioner     |         2 |      53.3s |       6.2% |
+| Build composition preconditioner|         2 |      4.59s |      0.53% |
+| Build temperature preconditioner|         2 |      4.75s |      0.55% |
+| Solve Stokes system             |         2 |       612s |        71% |
+| Solve composition system        |         2 |      1.34s |      0.16% |
+| Solve temperature system        |         2 |       1.4s |      0.16% |
+| Initialization                  |         1 |       0.2s |         0% |
+| Postprocessing                  |         2 |      4.33s |       0.5% |
+| Setup dof systems               |         1 |      3.18s |      0.37% |
+| Setup initial conditions        |         1 |      2.59s |       0.3% |
++---------------------------------+-----------+------------+------------+
+

--- a/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_1536_4_1
+++ b/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_1536_4_1
@@ -1,0 +1,100 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 2.0.0-pre (master, 7a539e8)
+--     . using deal.II 8.5.1 (v8.5.1, 0e5d7e8)
+--     . using Trilinos 12.10.1
+--     . using p4est 1.1.0
+--     . running in OPTIMIZED mode
+--     . running with 1536 MPI processes
+-----------------------------------------------------------------------------
+
+Number of active cells: 393,216 (on 5 levels)
+Number of degrees of freedom: 16,380,620 (9,585,030+405,570+3,195,010+3,195,010)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+13 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.0181 m/year, 0.0352 m/year
+     Temperature min/avg/max: 1521 K, 1600 K, 1679 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      22.1s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         1 |     0.566s |       2.6% |
+| Assemble composition system     |         1 |     0.252s |       1.1% |
+| Assemble temperature system     |         1 |     0.418s |       1.9% |
+| Build Stokes preconditioner     |         1 |      6.13s |        28% |
+| Build composition preconditioner|         1 |    0.0784s |      0.36% |
+| Build temperature preconditioner|         1 |    0.0687s |      0.31% |
+| Solve Stokes system             |         1 |      11.9s |        54% |
+| Solve composition system        |         1 |    0.0351s |      0.16% |
+| Solve temperature system        |         1 |     0.133s |       0.6% |
+| Initialization                  |         1 |     0.257s |       1.2% |
+| Postprocessing                  |         1 |    0.0618s |      0.28% |
+| Setup dof systems               |         1 |     0.439s |         2% |
+| Setup initial conditions        |         1 |     0.478s |       2.2% |
++---------------------------------+-----------+------------+------------+
+
+*** Timestep 1:  t=899873 years
+   Solving temperature system... 15 iterations.
+   Solving C_1 system ... 18 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+26 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.0181 m/year, 0.0353 m/year
+     Temperature min/avg/max: 1521 K, 1600 K, 1679 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      64.8s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |      1.16s |       1.8% |
+| Assemble composition system     |         2 |     0.496s |      0.77% |
+| Assemble temperature system     |         2 |     0.753s |       1.2% |
+| Build Stokes preconditioner     |         2 |      12.1s |        19% |
+| Build composition preconditioner|         2 |     0.122s |      0.19% |
+| Build temperature preconditioner|         2 |     0.158s |      0.24% |
+| Solve Stokes system             |         2 |      47.2s |        73% |
+| Solve composition system        |         2 |     0.105s |      0.16% |
+| Solve temperature system        |         2 |     0.181s |      0.28% |
+| Initialization                  |         1 |     0.257s |       0.4% |
+| Postprocessing                  |         2 |    0.0891s |      0.14% |
+| Setup dof systems               |         1 |     0.439s |      0.68% |
+| Setup initial conditions        |         1 |     0.478s |      0.74% |
++---------------------------------+-----------+------------+------------+
+
+Termination requested by criterion: end step
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      64.8s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |      1.16s |       1.8% |
+| Assemble composition system     |         2 |     0.496s |      0.77% |
+| Assemble temperature system     |         2 |     0.753s |       1.2% |
+| Build Stokes preconditioner     |         2 |      12.1s |        19% |
+| Build composition preconditioner|         2 |     0.122s |      0.19% |
+| Build temperature preconditioner|         2 |     0.158s |      0.24% |
+| Solve Stokes system             |         2 |      47.2s |        73% |
+| Solve composition system        |         2 |     0.105s |      0.16% |
+| Solve temperature system        |         2 |     0.181s |      0.28% |
+| Initialization                  |         1 |     0.257s |       0.4% |
+| Postprocessing                  |         2 |    0.0891s |      0.14% |
+| Setup dof systems               |         1 |     0.439s |      0.68% |
+| Setup initial conditions        |         1 |     0.478s |      0.74% |
++---------------------------------+-----------+------------+------------+
+

--- a/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_1536_5_1
+++ b/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_1536_5_1
@@ -1,0 +1,100 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 2.0.0-pre (master, 7a539e8)
+--     . using deal.II 8.5.1 (v8.5.1, 0e5d7e8)
+--     . using Trilinos 12.10.1
+--     . using p4est 1.1.0
+--     . running in OPTIMIZED mode
+--     . running with 1536 MPI processes
+-----------------------------------------------------------------------------
+
+Number of active cells: 3,145,728 (on 6 levels)
+Number of degrees of freedom: 130,008,460 (76,088,070+3,195,010+25,362,690+25,362,690)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+13 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.0181 m/year, 0.0351 m/year
+     Temperature min/avg/max: 1521 K, 1600 K, 1679 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      70.3s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         1 |      3.67s |       5.2% |
+| Assemble composition system     |         1 |      1.28s |       1.8% |
+| Assemble temperature system     |         1 |      1.91s |       2.7% |
+| Build Stokes preconditioner     |         1 |      5.56s |       7.9% |
+| Build composition preconditioner|         1 |     0.204s |      0.29% |
+| Build temperature preconditioner|         1 |     0.278s |      0.39% |
+| Solve Stokes system             |         1 |        51s |        73% |
+| Solve composition system        |         1 |      0.11s |      0.16% |
+| Solve temperature system        |         1 |     0.209s |       0.3% |
+| Initialization                  |         1 |      0.26s |      0.37% |
+| Postprocessing                  |         1 |     0.242s |      0.34% |
+| Setup dof systems               |         1 |     0.947s |       1.3% |
+| Setup initial conditions        |         1 |     0.778s |       1.1% |
++---------------------------------+-----------+------------+------------+
+
+*** Timestep 1:  t=450546 years
+   Solving temperature system... 14 iterations.
+   Solving C_1 system ... 17 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+28 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.0181 m/year, 0.0362 m/year
+     Temperature min/avg/max: 1521 K, 1600 K, 1679 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |       254s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |      7.48s |       2.9% |
+| Assemble composition system     |         2 |      2.72s |       1.1% |
+| Assemble temperature system     |         2 |      3.85s |       1.5% |
+| Build Stokes preconditioner     |         2 |      10.1s |         4% |
+| Build composition preconditioner|         2 |      0.48s |      0.19% |
+| Build temperature preconditioner|         2 |     0.536s |      0.21% |
+| Solve Stokes system             |         2 |       221s |        87% |
+| Solve composition system        |         2 |      0.44s |      0.17% |
+| Solve temperature system        |         2 |     0.402s |      0.16% |
+| Initialization                  |         1 |      0.26s |       0.1% |
+| Postprocessing                  |         2 |     0.516s |       0.2% |
+| Setup dof systems               |         1 |     0.947s |      0.37% |
+| Setup initial conditions        |         1 |     0.778s |      0.31% |
++---------------------------------+-----------+------------+------------+
+
+Termination requested by criterion: end step
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |       254s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |      7.48s |       2.9% |
+| Assemble composition system     |         2 |      2.72s |       1.1% |
+| Assemble temperature system     |         2 |      3.85s |       1.5% |
+| Build Stokes preconditioner     |         2 |      10.1s |         4% |
+| Build composition preconditioner|         2 |      0.48s |      0.19% |
+| Build temperature preconditioner|         2 |     0.536s |      0.21% |
+| Solve Stokes system             |         2 |       221s |        87% |
+| Solve composition system        |         2 |      0.44s |      0.17% |
+| Solve temperature system        |         2 |     0.402s |      0.16% |
+| Initialization                  |         1 |      0.26s |       0.1% |
+| Postprocessing                  |         2 |     0.516s |       0.2% |
+| Setup dof systems               |         1 |     0.947s |      0.37% |
+| Setup initial conditions        |         1 |     0.778s |      0.31% |
++---------------------------------+-----------+------------+------------+
+

--- a/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_192_2_1
+++ b/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_192_2_1
@@ -1,0 +1,100 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 2.0.0-pre (master, 7a539e8)
+--     . using deal.II 8.5.1 (v8.5.1, 0e5d7e8)
+--     . using Trilinos 12.10.1
+--     . using p4est 1.1.0
+--     . running in OPTIMIZED mode
+--     . running with 192 MPI processes
+-----------------------------------------------------------------------------
+
+Number of active cells: 6,144 (on 3 levels)
+Number of degrees of freedom: 268,220 (156,774+6,930+52,258+52,258)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+24 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.0181 m/year, 0.0426 m/year
+     Temperature min/avg/max: 1522 K, 1600 K, 1678 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      6.04s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         1 |    0.0966s |       1.6% |
+| Assemble composition system     |         1 |    0.0358s |      0.59% |
+| Assemble temperature system     |         1 |    0.0999s |       1.7% |
+| Build Stokes preconditioner     |         1 |      1.85s |        31% |
+| Build composition preconditioner|         1 |   0.00274s |         0% |
+| Build temperature preconditioner|         1 |    0.0546s |       0.9% |
+| Solve Stokes system             |         1 |       2.9s |        48% |
+| Solve composition system        |         1 |   0.00627s |       0.1% |
+| Solve temperature system        |         1 |    0.0595s |      0.98% |
+| Initialization                  |         1 |     0.239s |         4% |
+| Postprocessing                  |         1 |    0.0963s |       1.6% |
+| Setup dof systems               |         1 |      0.19s |       3.2% |
+| Setup initial conditions        |         1 |     0.102s |       1.7% |
++---------------------------------+-----------+------------+------------+
+
+*** Timestep 1:  t=2.25485e+06 years
+   Solving temperature system... 17 iterations.
+   Solving C_1 system ... 18 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+22 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.018 m/year, 0.0423 m/year
+     Temperature min/avg/max: 1523 K, 1600 K, 1678 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      11.6s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |     0.186s |       1.6% |
+| Assemble composition system     |         2 |    0.0719s |      0.62% |
+| Assemble temperature system     |         2 |     0.149s |       1.3% |
+| Build Stokes preconditioner     |         2 |      3.41s |        29% |
+| Build composition preconditioner|         2 |   0.00551s |         0% |
+| Build temperature preconditioner|         2 |    0.0637s |      0.55% |
+| Solve Stokes system             |         2 |      6.64s |        57% |
+| Solve composition system        |         2 |    0.0216s |      0.19% |
+| Solve temperature system        |         2 |    0.0714s |      0.62% |
+| Initialization                  |         1 |     0.239s |       2.1% |
+| Postprocessing                  |         2 |     0.103s |      0.89% |
+| Setup dof systems               |         1 |      0.19s |       1.6% |
+| Setup initial conditions        |         1 |     0.102s |      0.89% |
++---------------------------------+-----------+------------+------------+
+
+Termination requested by criterion: end step
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      11.6s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |     0.186s |       1.6% |
+| Assemble composition system     |         2 |    0.0719s |      0.62% |
+| Assemble temperature system     |         2 |     0.149s |       1.3% |
+| Build Stokes preconditioner     |         2 |      3.41s |        29% |
+| Build composition preconditioner|         2 |   0.00551s |         0% |
+| Build temperature preconditioner|         2 |    0.0637s |      0.55% |
+| Solve Stokes system             |         2 |      6.64s |        57% |
+| Solve composition system        |         2 |    0.0216s |      0.19% |
+| Solve temperature system        |         2 |    0.0714s |      0.62% |
+| Initialization                  |         1 |     0.239s |       2.1% |
+| Postprocessing                  |         2 |     0.103s |      0.89% |
+| Setup dof systems               |         1 |      0.19s |       1.6% |
+| Setup initial conditions        |         1 |     0.102s |      0.89% |
++---------------------------------+-----------+------------+------------+
+

--- a/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_192_3_1
+++ b/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_192_3_1
@@ -1,0 +1,100 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 2.0.0-pre (master, 7a539e8)
+--     . using deal.II 8.5.1 (v8.5.1, 0e5d7e8)
+--     . using Trilinos 12.10.1
+--     . using p4est 1.1.0
+--     . running in OPTIMIZED mode
+--     . running with 192 MPI processes
+-----------------------------------------------------------------------------
+
+Number of active cells: 49,152 (on 4 levels)
+Number of degrees of freedom: 2,080,108 (1,216,710+52,258+405,570+405,570)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+26 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.0181 m/year, 0.0361 m/year
+     Temperature min/avg/max: 1521 K, 1600 K, 1679 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      12.7s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         1 |     0.507s |         4% |
+| Assemble composition system     |         1 |     0.211s |       1.7% |
+| Assemble temperature system     |         1 |     0.296s |       2.3% |
+| Build Stokes preconditioner     |         1 |      1.34s |        11% |
+| Build composition preconditioner|         1 |    0.0654s |      0.51% |
+| Build temperature preconditioner|         1 |    0.0655s |      0.52% |
+| Solve Stokes system             |         1 |      8.85s |        70% |
+| Solve composition system        |         1 |    0.0164s |      0.13% |
+| Solve temperature system        |         1 |    0.0608s |      0.48% |
+| Initialization                  |         1 |     0.213s |       1.7% |
+| Postprocessing                  |         1 |     0.038s |       0.3% |
+| Setup dof systems               |         1 |     0.232s |       1.8% |
+| Setup initial conditions        |         1 |     0.129s |         1% |
++---------------------------------+-----------+------------+------------+
+
+*** Timestep 1:  t=1.70582e+06 years
+   Solving temperature system... 16 iterations.
+   Solving C_1 system ... 18 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+24 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.018 m/year, 0.0351 m/year
+     Temperature min/avg/max: 1522 K, 1600 K, 1678 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      31.2s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |      1.01s |       3.2% |
+| Assemble composition system     |         2 |     0.408s |       1.3% |
+| Assemble temperature system     |         2 |     0.538s |       1.7% |
+| Build Stokes preconditioner     |         2 |       2.4s |       7.7% |
+| Build composition preconditioner|         2 |    0.0856s |      0.27% |
+| Build temperature preconditioner|         2 |    0.0856s |      0.27% |
+| Solve Stokes system             |         2 |      25.2s |        81% |
+| Solve composition system        |         2 |    0.0442s |      0.14% |
+| Solve temperature system        |         2 |    0.0867s |      0.28% |
+| Initialization                  |         1 |     0.213s |      0.68% |
+| Postprocessing                  |         2 |    0.0641s |      0.21% |
+| Setup dof systems               |         1 |     0.232s |      0.75% |
+| Setup initial conditions        |         1 |     0.129s |      0.42% |
++---------------------------------+-----------+------------+------------+
+
+Termination requested by criterion: end step
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      31.2s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |      1.01s |       3.2% |
+| Assemble composition system     |         2 |     0.408s |       1.3% |
+| Assemble temperature system     |         2 |     0.538s |       1.7% |
+| Build Stokes preconditioner     |         2 |       2.4s |       7.7% |
+| Build composition preconditioner|         2 |    0.0856s |      0.27% |
+| Build temperature preconditioner|         2 |    0.0856s |      0.27% |
+| Solve Stokes system             |         2 |      25.2s |        81% |
+| Solve composition system        |         2 |    0.0442s |      0.14% |
+| Solve temperature system        |         2 |    0.0867s |      0.28% |
+| Initialization                  |         1 |     0.213s |      0.68% |
+| Postprocessing                  |         2 |    0.0641s |      0.21% |
+| Setup dof systems               |         1 |     0.232s |      0.75% |
+| Setup initial conditions        |         1 |     0.129s |      0.42% |
++---------------------------------+-----------+------------+------------+
+

--- a/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_192_4_1
+++ b/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_192_4_1
@@ -1,0 +1,100 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 2.0.0-pre (master, 7a539e8)
+--     . using deal.II 8.5.1 (v8.5.1, 0e5d7e8)
+--     . using Trilinos 12.10.1
+--     . using p4est 1.1.0
+--     . running in OPTIMIZED mode
+--     . running with 192 MPI processes
+-----------------------------------------------------------------------------
+
+Number of active cells: 393,216 (on 5 levels)
+Number of degrees of freedom: 16,380,620 (9,585,030+405,570+3,195,010+3,195,010)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+13 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.0181 m/year, 0.0351 m/year
+     Temperature min/avg/max: 1521 K, 1600 K, 1679 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      34.1s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         1 |       3.4s |        10% |
+| Assemble composition system     |         1 |      1.11s |       3.2% |
+| Assemble temperature system     |         1 |      1.59s |       4.7% |
+| Build Stokes preconditioner     |         1 |      3.83s |        11% |
+| Build composition preconditioner|         1 |     0.202s |      0.59% |
+| Build temperature preconditioner|         1 |     0.212s |      0.62% |
+| Solve Stokes system             |         1 |      19.6s |        58% |
+| Solve composition system        |         1 |    0.0307s |         0% |
+| Solve temperature system        |         1 |     0.107s |      0.31% |
+| Initialization                  |         1 |     0.222s |      0.65% |
+| Postprocessing                  |         1 |     0.199s |      0.58% |
+| Setup dof systems               |         1 |     0.627s |       1.8% |
+| Setup initial conditions        |         1 |     0.385s |       1.1% |
++---------------------------------+-----------+------------+------------+
+
+*** Timestep 1:  t=901297 years
+   Solving temperature system... 15 iterations.
+   Solving C_1 system ... 17 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+26 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.0181 m/year, 0.035 m/year
+     Temperature min/avg/max: 1521 K, 1600 K, 1679 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |       105s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |      6.97s |       6.6% |
+| Assemble composition system     |         2 |      2.31s |       2.2% |
+| Assemble temperature system     |         2 |      3.35s |       3.2% |
+| Build Stokes preconditioner     |         2 |      7.43s |       7.1% |
+| Build composition preconditioner|         2 |      0.39s |      0.37% |
+| Build temperature preconditioner|         2 |     0.388s |      0.37% |
+| Solve Stokes system             |         2 |      79.5s |        76% |
+| Solve composition system        |         2 |     0.197s |      0.19% |
+| Solve temperature system        |         2 |     0.258s |      0.25% |
+| Initialization                  |         1 |     0.222s |      0.21% |
+| Postprocessing                  |         2 |     0.386s |      0.37% |
+| Setup dof systems               |         1 |     0.627s |       0.6% |
+| Setup initial conditions        |         1 |     0.385s |      0.37% |
++---------------------------------+-----------+------------+------------+
+
+Termination requested by criterion: end step
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |       105s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |      6.97s |       6.6% |
+| Assemble composition system     |         2 |      2.31s |       2.2% |
+| Assemble temperature system     |         2 |      3.35s |       3.2% |
+| Build Stokes preconditioner     |         2 |      7.43s |       7.1% |
+| Build composition preconditioner|         2 |      0.39s |      0.37% |
+| Build temperature preconditioner|         2 |     0.388s |      0.37% |
+| Solve Stokes system             |         2 |      79.5s |        76% |
+| Solve composition system        |         2 |     0.197s |      0.19% |
+| Solve temperature system        |         2 |     0.258s |      0.25% |
+| Initialization                  |         1 |     0.222s |      0.21% |
+| Postprocessing                  |         2 |     0.386s |      0.37% |
+| Setup dof systems               |         1 |     0.627s |       0.6% |
+| Setup initial conditions        |         1 |     0.385s |      0.37% |
++---------------------------------+-----------+------------+------------+
+

--- a/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_192_5_1
+++ b/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_192_5_1
@@ -1,0 +1,100 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 2.0.0-pre (master, 7a539e8)
+--     . using deal.II 8.5.1 (v8.5.1, 0e5d7e8)
+--     . using Trilinos 12.10.1
+--     . using p4est 1.1.0
+--     . running in OPTIMIZED mode
+--     . running with 192 MPI processes
+-----------------------------------------------------------------------------
+
+Number of active cells: 3,145,728 (on 6 levels)
+Number of degrees of freedom: 130,008,460 (76,088,070+3,195,010+25,362,690+25,362,690)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+13 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.0181 m/year, 0.0351 m/year
+     Temperature min/avg/max: 1521 K, 1600 K, 1679 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |       255s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         1 |      26.1s |        10% |
+| Assemble composition system     |         1 |      7.24s |       2.8% |
+| Assemble temperature system     |         1 |      11.9s |       4.7% |
+| Build Stokes preconditioner     |         1 |      18.6s |       7.3% |
+| Build composition preconditioner|         1 |      1.45s |      0.57% |
+| Build temperature preconditioner|         1 |      1.53s |       0.6% |
+| Solve Stokes system             |         1 |       167s |        66% |
+| Solve composition system        |         1 |     0.274s |      0.11% |
+| Solve temperature system        |         1 |     0.327s |      0.13% |
+| Initialization                  |         1 |     0.266s |       0.1% |
+| Postprocessing                  |         1 |      1.37s |      0.54% |
+| Setup dof systems               |         1 |      2.61s |         1% |
+| Setup initial conditions        |         1 |      2.04s |       0.8% |
++---------------------------------+-----------+------------+------------+
+
+*** Timestep 1:  t=450545 years
+   Solving temperature system... 13 iterations.
+   Solving C_1 system ... 16 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+28 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.0181 m/year, 0.0362 m/year
+     Temperature min/avg/max: 1521 K, 1600 K, 1679 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |       892s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |      53.7s |         6% |
+| Assemble composition system     |         2 |      15.8s |       1.8% |
+| Assemble temperature system     |         2 |      25.1s |       2.8% |
+| Build Stokes preconditioner     |         2 |      40.6s |       4.6% |
+| Build composition preconditioner|         2 |      2.93s |      0.33% |
+| Build temperature preconditioner|         2 |         3s |      0.34% |
+| Solve Stokes system             |         2 |       725s |        81% |
+| Solve composition system        |         2 |      1.68s |      0.19% |
+| Solve temperature system        |         2 |      1.35s |      0.15% |
+| Initialization                  |         1 |     0.266s |         0% |
+| Postprocessing                  |         2 |      2.71s |       0.3% |
+| Setup dof systems               |         1 |      2.61s |      0.29% |
+| Setup initial conditions        |         1 |      2.04s |      0.23% |
++---------------------------------+-----------+------------+------------+
+
+Termination requested by criterion: end step
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |       892s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |      53.7s |         6% |
+| Assemble composition system     |         2 |      15.8s |       1.8% |
+| Assemble temperature system     |         2 |      25.1s |       2.8% |
+| Build Stokes preconditioner     |         2 |      40.6s |       4.6% |
+| Build composition preconditioner|         2 |      2.93s |      0.33% |
+| Build temperature preconditioner|         2 |         3s |      0.34% |
+| Solve Stokes system             |         2 |       725s |        81% |
+| Solve composition system        |         2 |      1.68s |      0.19% |
+| Solve temperature system        |         2 |      1.35s |      0.15% |
+| Initialization                  |         1 |     0.266s |         0% |
+| Postprocessing                  |         2 |      2.71s |       0.3% |
+| Setup dof systems               |         1 |      2.61s |      0.29% |
+| Setup initial conditions        |         1 |      2.04s |      0.23% |
++---------------------------------+-----------+------------+------------+
+

--- a/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_1_2_1
+++ b/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_1_2_1
@@ -1,0 +1,100 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 2.0.0-pre (master, 7a539e8)
+--     . using deal.II 8.5.1 (v8.5.1, 0e5d7e8)
+--     . using Trilinos 12.10.1
+--     . using p4est 1.1.0
+--     . running in OPTIMIZED mode
+--     . running with 1 MPI process
+-----------------------------------------------------------------------------
+
+Number of active cells: 6,144 (on 3 levels)
+Number of degrees of freedom: 268,220 (156,774+6,930+52,258+52,258)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+24 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.0181 m/year, 0.0426 m/year
+     Temperature min/avg/max: 1522 K, 1600 K, 1678 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      70.2s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         1 |      6.55s |       9.3% |
+| Assemble composition system     |         1 |      1.48s |       2.1% |
+| Assemble temperature system     |         1 |      2.65s |       3.8% |
+| Build Stokes preconditioner     |         1 |       4.2s |         6% |
+| Build composition preconditioner|         1 |     0.295s |      0.42% |
+| Build temperature preconditioner|         1 |     0.323s |      0.46% |
+| Solve Stokes system             |         1 |        51s |        73% |
+| Solve composition system        |         1 |    0.0123s |         0% |
+| Solve temperature system        |         1 |    0.0408s |         0% |
+| Initialization                  |         1 |     0.184s |      0.26% |
+| Postprocessing                  |         1 |     0.366s |      0.52% |
+| Setup dof systems               |         1 |     0.473s |      0.67% |
+| Setup initial conditions        |         1 |     0.416s |      0.59% |
++---------------------------------+-----------+------------+------------+
+
+*** Timestep 1:  t=2.2539e+06 years
+   Solving temperature system... 9 iterations.
+   Solving C_1 system ... 10 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+23 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.018 m/year, 0.0423 m/year
+     Temperature min/avg/max: 1523 K, 1600 K, 1678 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |       159s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |      13.6s |       8.5% |
+| Assemble composition system     |         2 |      3.37s |       2.1% |
+| Assemble temperature system     |         2 |      5.72s |       3.6% |
+| Build Stokes preconditioner     |         2 |      8.44s |       5.3% |
+| Build composition preconditioner|         2 |     0.589s |      0.37% |
+| Build temperature preconditioner|         2 |     0.632s |       0.4% |
+| Solve Stokes system             |         2 |       122s |        77% |
+| Solve composition system        |         2 |     0.126s |         0% |
+| Solve temperature system        |         2 |     0.137s |         0% |
+| Initialization                  |         1 |     0.184s |      0.12% |
+| Postprocessing                  |         2 |     0.728s |      0.46% |
+| Setup dof systems               |         1 |     0.473s |       0.3% |
+| Setup initial conditions        |         1 |     0.416s |      0.26% |
++---------------------------------+-----------+------------+------------+
+
+Termination requested by criterion: end step
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |       159s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |      13.6s |       8.5% |
+| Assemble composition system     |         2 |      3.37s |       2.1% |
+| Assemble temperature system     |         2 |      5.72s |       3.6% |
+| Build Stokes preconditioner     |         2 |      8.44s |       5.3% |
+| Build composition preconditioner|         2 |     0.589s |      0.37% |
+| Build temperature preconditioner|         2 |     0.632s |       0.4% |
+| Solve Stokes system             |         2 |       122s |        77% |
+| Solve composition system        |         2 |     0.126s |         0% |
+| Solve temperature system        |         2 |     0.137s |         0% |
+| Initialization                  |         1 |     0.184s |      0.12% |
+| Postprocessing                  |         2 |     0.728s |      0.46% |
+| Setup dof systems               |         1 |     0.473s |       0.3% |
+| Setup initial conditions        |         1 |     0.416s |      0.26% |
++---------------------------------+-----------+------------+------------+
+

--- a/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_1_3_1
+++ b/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_1_3_1
@@ -1,0 +1,100 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 2.0.0-pre (master, 7a539e8)
+--     . using deal.II 8.5.1 (v8.5.1, 0e5d7e8)
+--     . using Trilinos 12.10.1
+--     . using p4est 1.1.0
+--     . running in OPTIMIZED mode
+--     . running with 1 MPI process
+-----------------------------------------------------------------------------
+
+Number of active cells: 49,152 (on 4 levels)
+Number of degrees of freedom: 2,080,108 (1,216,710+52,258+405,570+405,570)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+27 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.0181 m/year, 0.0357 m/year
+     Temperature min/avg/max: 1521 K, 1600 K, 1679 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |       594s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         1 |      53.3s |         9% |
+| Assemble composition system     |         1 |      11.7s |         2% |
+| Assemble temperature system     |         1 |      20.9s |       3.5% |
+| Build Stokes preconditioner     |         1 |      32.8s |       5.5% |
+| Build composition preconditioner|         1 |      2.42s |      0.41% |
+| Build temperature preconditioner|         1 |      2.48s |      0.42% |
+| Solve Stokes system             |         1 |       444s |        75% |
+| Solve composition system        |         1 |      0.09s |         0% |
+| Solve temperature system        |         1 |     0.119s |         0% |
+| Initialization                  |         1 |     0.171s |         0% |
+| Postprocessing                  |         1 |      2.72s |      0.46% |
+| Setup dof systems               |         1 |      2.55s |      0.43% |
+| Setup initial conditions        |         1 |      2.72s |      0.46% |
++---------------------------------+-----------+------------+------------+
+
+*** Timestep 1:  t=1.72469e+06 years
+   Solving temperature system... 9 iterations.
+   Solving C_1 system ... 10 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+24 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.018 m/year, 0.0353 m/year
+     Temperature min/avg/max: 1522 K, 1600 K, 1678 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |  1.46e+03s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |       111s |       7.6% |
+| Assemble composition system     |         2 |        27s |       1.8% |
+| Assemble temperature system     |         2 |      46.6s |       3.2% |
+| Build Stokes preconditioner     |         2 |      68.8s |       4.7% |
+| Build composition preconditioner|         2 |      4.92s |      0.34% |
+| Build temperature preconditioner|         2 |      4.94s |      0.34% |
+| Solve Stokes system             |         2 |  1.17e+03s |        80% |
+| Solve composition system        |         2 |     0.953s |         0% |
+| Solve temperature system        |         2 |     0.943s |         0% |
+| Initialization                  |         1 |     0.171s |         0% |
+| Postprocessing                  |         2 |      5.64s |      0.39% |
+| Setup dof systems               |         1 |      2.55s |      0.17% |
+| Setup initial conditions        |         1 |      2.72s |      0.19% |
++---------------------------------+-----------+------------+------------+
+
+Termination requested by criterion: end step
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |  1.46e+03s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |       111s |       7.6% |
+| Assemble composition system     |         2 |        27s |       1.8% |
+| Assemble temperature system     |         2 |      46.6s |       3.2% |
+| Build Stokes preconditioner     |         2 |      68.8s |       4.7% |
+| Build composition preconditioner|         2 |      4.92s |      0.34% |
+| Build temperature preconditioner|         2 |      4.94s |      0.34% |
+| Solve Stokes system             |         2 |  1.17e+03s |        80% |
+| Solve composition system        |         2 |     0.953s |         0% |
+| Solve temperature system        |         2 |     0.943s |         0% |
+| Initialization                  |         1 |     0.171s |         0% |
+| Postprocessing                  |         2 |      5.64s |      0.39% |
+| Setup dof systems               |         1 |      2.55s |      0.17% |
+| Setup initial conditions        |         1 |      2.72s |      0.19% |
++---------------------------------+-----------+------------+------------+
+

--- a/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_24_2_1
+++ b/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_24_2_1
@@ -1,0 +1,100 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 2.0.0-pre (master, 7a539e8)
+--     . using deal.II 8.5.1 (v8.5.1, 0e5d7e8)
+--     . using Trilinos 12.10.1
+--     . using p4est 1.1.0
+--     . running in OPTIMIZED mode
+--     . running with 24 MPI processes
+-----------------------------------------------------------------------------
+
+Number of active cells: 6,144 (on 3 levels)
+Number of degrees of freedom: 268,220 (156,774+6,930+52,258+52,258)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+24 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.0181 m/year, 0.0426 m/year
+     Temperature min/avg/max: 1522 K, 1600 K, 1678 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      5.39s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         1 |     0.394s |       7.3% |
+| Assemble composition system     |         1 |     0.124s |       2.3% |
+| Assemble temperature system     |         1 |     0.201s |       3.7% |
+| Build Stokes preconditioner     |         1 |     0.462s |       8.6% |
+| Build composition preconditioner|         1 |    0.0176s |      0.33% |
+| Build temperature preconditioner|         1 |    0.0537s |         1% |
+| Solve Stokes system             |         1 |      3.19s |        59% |
+| Solve composition system        |         1 |   0.00362s |         0% |
+| Solve temperature system        |         1 |    0.0367s |      0.68% |
+| Initialization                  |         1 |     0.191s |       3.5% |
+| Postprocessing                  |         1 |    0.0276s |      0.51% |
+| Setup dof systems               |         1 |     0.227s |       4.2% |
+| Setup initial conditions        |         1 |    0.0925s |       1.7% |
++---------------------------------+-----------+------------+------------+
+
+*** Timestep 1:  t=2.25269e+06 years
+   Solving temperature system... 15 iterations.
+   Solving C_1 system ... 16 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+22 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.018 m/year, 0.0423 m/year
+     Temperature min/avg/max: 1523 K, 1600 K, 1678 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |        11s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |     0.806s |       7.4% |
+| Assemble composition system     |         2 |     0.262s |       2.4% |
+| Assemble temperature system     |         2 |     0.398s |       3.6% |
+| Build Stokes preconditioner     |         2 |     0.763s |         7% |
+| Build composition preconditioner|         2 |    0.0348s |      0.32% |
+| Build temperature preconditioner|         2 |    0.0708s |      0.65% |
+| Solve Stokes system             |         2 |       7.6s |        69% |
+| Solve composition system        |         2 |    0.0176s |      0.16% |
+| Solve temperature system        |         2 |    0.0498s |      0.45% |
+| Initialization                  |         1 |     0.191s |       1.7% |
+| Postprocessing                  |         2 |    0.0513s |      0.47% |
+| Setup dof systems               |         1 |     0.227s |       2.1% |
+| Setup initial conditions        |         1 |    0.0925s |      0.84% |
++---------------------------------+-----------+------------+------------+
+
+Termination requested by criterion: end step
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |        11s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |     0.806s |       7.4% |
+| Assemble composition system     |         2 |     0.262s |       2.4% |
+| Assemble temperature system     |         2 |     0.398s |       3.6% |
+| Build Stokes preconditioner     |         2 |     0.763s |         7% |
+| Build composition preconditioner|         2 |    0.0348s |      0.32% |
+| Build temperature preconditioner|         2 |    0.0708s |      0.65% |
+| Solve Stokes system             |         2 |       7.6s |        69% |
+| Solve composition system        |         2 |    0.0176s |      0.16% |
+| Solve temperature system        |         2 |    0.0498s |      0.45% |
+| Initialization                  |         1 |     0.191s |       1.7% |
+| Postprocessing                  |         2 |    0.0513s |      0.47% |
+| Setup dof systems               |         1 |     0.227s |       2.1% |
+| Setup initial conditions        |         1 |    0.0925s |      0.84% |
++---------------------------------+-----------+------------+------------+
+

--- a/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_24_3_1
+++ b/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_24_3_1
@@ -1,0 +1,100 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 2.0.0-pre (master, 7a539e8)
+--     . using deal.II 8.5.1 (v8.5.1, 0e5d7e8)
+--     . using Trilinos 12.10.1
+--     . using p4est 1.1.0
+--     . running in OPTIMIZED mode
+--     . running with 24 MPI processes
+-----------------------------------------------------------------------------
+
+Number of active cells: 49,152 (on 4 levels)
+Number of degrees of freedom: 2,080,108 (1,216,710+52,258+405,570+405,570)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+26 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.0181 m/year, 0.0357 m/year
+     Temperature min/avg/max: 1521 K, 1600 K, 1679 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      37.4s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         1 |      2.86s |       7.6% |
+| Assemble composition system     |         1 |      0.82s |       2.2% |
+| Assemble temperature system     |         1 |      1.32s |       3.5% |
+| Build Stokes preconditioner     |         1 |      2.82s |       7.5% |
+| Build composition preconditioner|         1 |     0.139s |      0.37% |
+| Build temperature preconditioner|         1 |     0.169s |      0.45% |
+| Solve Stokes system             |         1 |      26.5s |        71% |
+| Solve composition system        |         1 |    0.0181s |         0% |
+| Solve temperature system        |         1 |    0.0565s |      0.15% |
+| Initialization                  |         1 |     0.188s |       0.5% |
+| Postprocessing                  |         1 |     0.156s |      0.42% |
+| Setup dof systems               |         1 |     0.495s |       1.3% |
+| Setup initial conditions        |         1 |     0.247s |      0.66% |
++---------------------------------+-----------+------------+------------+
+
+*** Timestep 1:  t=1.72523e+06 years
+   Solving temperature system... 14 iterations.
+   Solving C_1 system ... 16 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+24 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.018 m/year, 0.0352 m/year
+     Temperature min/avg/max: 1522 K, 1600 K, 1678 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      95.6s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |      5.84s |       6.1% |
+| Assemble composition system     |         2 |      1.79s |       1.9% |
+| Assemble temperature system     |         2 |      2.72s |       2.8% |
+| Build Stokes preconditioner     |         2 |      5.63s |       5.9% |
+| Build composition preconditioner|         2 |     0.283s |       0.3% |
+| Build temperature preconditioner|         2 |     0.314s |      0.33% |
+| Solve Stokes system             |         2 |      75.8s |        79% |
+| Solve composition system        |         2 |     0.107s |      0.11% |
+| Solve temperature system        |         2 |     0.137s |      0.14% |
+| Initialization                  |         1 |     0.188s |       0.2% |
+| Postprocessing                  |         2 |     0.303s |      0.32% |
+| Setup dof systems               |         1 |     0.495s |      0.52% |
+| Setup initial conditions        |         1 |     0.247s |      0.26% |
++---------------------------------+-----------+------------+------------+
+
+Termination requested by criterion: end step
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      95.6s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |      5.84s |       6.1% |
+| Assemble composition system     |         2 |      1.79s |       1.9% |
+| Assemble temperature system     |         2 |      2.72s |       2.8% |
+| Build Stokes preconditioner     |         2 |      5.63s |       5.9% |
+| Build composition preconditioner|         2 |     0.283s |       0.3% |
+| Build temperature preconditioner|         2 |     0.314s |      0.33% |
+| Solve Stokes system             |         2 |      75.8s |        79% |
+| Solve composition system        |         2 |     0.107s |      0.11% |
+| Solve temperature system        |         2 |     0.137s |      0.14% |
+| Initialization                  |         1 |     0.188s |       0.2% |
+| Postprocessing                  |         2 |     0.303s |      0.32% |
+| Setup dof systems               |         1 |     0.495s |      0.52% |
+| Setup initial conditions        |         1 |     0.247s |      0.26% |
++---------------------------------+-----------+------------+------------+
+

--- a/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_24_4_1
+++ b/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_24_4_1
@@ -1,0 +1,100 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 2.0.0-pre (master, 7a539e8)
+--     . using deal.II 8.5.1 (v8.5.1, 0e5d7e8)
+--     . using Trilinos 12.10.1
+--     . using p4est 1.1.0
+--     . running in OPTIMIZED mode
+--     . running with 24 MPI processes
+-----------------------------------------------------------------------------
+
+Number of active cells: 393,216 (on 5 levels)
+Number of degrees of freedom: 16,380,620 (9,585,030+405,570+3,195,010+3,195,010)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+13 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.0181 m/year, 0.0351 m/year
+     Temperature min/avg/max: 1521 K, 1600 K, 1679 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |       150s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         1 |      21.7s |        14% |
+| Assemble composition system     |         1 |         6s |         4% |
+| Assemble temperature system     |         1 |      9.61s |       6.4% |
+| Build Stokes preconditioner     |         1 |      13.8s |       9.2% |
+| Build composition preconditioner|         1 |      1.17s |      0.78% |
+| Build temperature preconditioner|         1 |      1.21s |       0.8% |
+| Solve Stokes system             |         1 |      81.4s |        54% |
+| Solve composition system        |         1 |     0.132s |         0% |
+| Solve temperature system        |         1 |     0.165s |      0.11% |
+| Initialization                  |         1 |     0.209s |      0.14% |
+| Postprocessing                  |         1 |      1.14s |      0.76% |
+| Setup dof systems               |         1 |      2.01s |       1.3% |
+| Setup initial conditions        |         1 |      1.46s |      0.97% |
++---------------------------------+-----------+------------+------------+
+
+*** Timestep 1:  t=900816 years
+   Solving temperature system... 13 iterations.
+   Solving C_1 system ... 15 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+26 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.0181 m/year, 0.0353 m/year
+     Temperature min/avg/max: 1521 K, 1600 K, 1679 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |       454s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |      44.6s |       9.8% |
+| Assemble composition system     |         2 |      13.3s |       2.9% |
+| Assemble temperature system     |         2 |      20.5s |       4.5% |
+| Build Stokes preconditioner     |         2 |      28.1s |       6.2% |
+| Build composition preconditioner|         2 |      2.32s |      0.51% |
+| Build temperature preconditioner|         2 |       2.4s |      0.53% |
+| Solve Stokes system             |         2 |       324s |        71% |
+| Solve composition system        |         2 |      0.78s |      0.17% |
+| Solve temperature system        |         2 |     0.756s |      0.17% |
+| Initialization                  |         1 |     0.209s |         0% |
+| Postprocessing                  |         2 |      2.29s |       0.5% |
+| Setup dof systems               |         1 |      2.01s |      0.44% |
+| Setup initial conditions        |         1 |      1.46s |      0.32% |
++---------------------------------+-----------+------------+------------+
+
+Termination requested by criterion: end step
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |       454s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |      44.6s |       9.8% |
+| Assemble composition system     |         2 |      13.3s |       2.9% |
+| Assemble temperature system     |         2 |      20.5s |       4.5% |
+| Build Stokes preconditioner     |         2 |      28.1s |       6.2% |
+| Build composition preconditioner|         2 |      2.32s |      0.51% |
+| Build temperature preconditioner|         2 |       2.4s |      0.53% |
+| Solve Stokes system             |         2 |       324s |        71% |
+| Solve composition system        |         2 |      0.78s |      0.17% |
+| Solve temperature system        |         2 |     0.756s |      0.17% |
+| Initialization                  |         1 |     0.209s |         0% |
+| Postprocessing                  |         2 |      2.29s |       0.5% |
+| Setup dof systems               |         1 |      2.01s |      0.44% |
+| Setup initial conditions        |         1 |      1.46s |      0.32% |
++---------------------------------+-----------+------------+------------+
+

--- a/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_2_2_1
+++ b/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_2_2_1
@@ -1,0 +1,100 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 2.0.0-pre (master, 7a539e8)
+--     . using deal.II 8.5.1 (v8.5.1, 0e5d7e8)
+--     . using Trilinos 12.10.1
+--     . using p4est 1.1.0
+--     . running in OPTIMIZED mode
+--     . running with 2 MPI processes
+-----------------------------------------------------------------------------
+
+Number of active cells: 6,144 (on 3 levels)
+Number of degrees of freedom: 268,220 (156,774+6,930+52,258+52,258)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+24 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.0181 m/year, 0.0426 m/year
+     Temperature min/avg/max: 1522 K, 1600 K, 1678 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      36.9s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         1 |       3.5s |       9.5% |
+| Assemble composition system     |         1 |     0.975s |       2.6% |
+| Assemble temperature system     |         1 |      1.57s |       4.3% |
+| Build Stokes preconditioner     |         1 |      2.28s |       6.2% |
+| Build composition preconditioner|         1 |     0.188s |      0.51% |
+| Build temperature preconditioner|         1 |      0.21s |      0.57% |
+| Solve Stokes system             |         1 |      25.4s |        69% |
+| Solve composition system        |         1 |    0.0191s |         0% |
+| Solve temperature system        |         1 |    0.0492s |      0.13% |
+| Initialization                  |         1 |     0.202s |      0.55% |
+| Postprocessing                  |         1 |     0.205s |      0.56% |
+| Setup dof systems               |         1 |     0.444s |       1.2% |
+| Setup initial conditions        |         1 |     0.277s |      0.75% |
++---------------------------------+-----------+------------+------------+
+
+*** Timestep 1:  t=2.25374e+06 years
+   Solving temperature system... 12 iterations.
+   Solving C_1 system ... 13 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+22 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.018 m/year, 0.0423 m/year
+     Temperature min/avg/max: 1523 K, 1600 K, 1678 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      86.1s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |      7.21s |       8.4% |
+| Assemble composition system     |         2 |      2.14s |       2.5% |
+| Assemble temperature system     |         2 |      3.31s |       3.8% |
+| Build Stokes preconditioner     |         2 |      4.57s |       5.3% |
+| Build composition preconditioner|         2 |     0.372s |      0.43% |
+| Build temperature preconditioner|         2 |     0.395s |      0.46% |
+| Solve Stokes system             |         2 |      64.8s |        75% |
+| Solve composition system        |         2 |    0.0951s |      0.11% |
+| Solve temperature system        |         2 |     0.121s |      0.14% |
+| Initialization                  |         1 |     0.202s |      0.23% |
+| Postprocessing                  |         2 |     0.421s |      0.49% |
+| Setup dof systems               |         1 |     0.444s |      0.52% |
+| Setup initial conditions        |         1 |     0.277s |      0.32% |
++---------------------------------+-----------+------------+------------+
+
+Termination requested by criterion: end step
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      86.1s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |      7.21s |       8.4% |
+| Assemble composition system     |         2 |      2.14s |       2.5% |
+| Assemble temperature system     |         2 |      3.31s |       3.8% |
+| Build Stokes preconditioner     |         2 |      4.57s |       5.3% |
+| Build composition preconditioner|         2 |     0.372s |      0.43% |
+| Build temperature preconditioner|         2 |     0.395s |      0.46% |
+| Solve Stokes system             |         2 |      64.8s |        75% |
+| Solve composition system        |         2 |    0.0951s |      0.11% |
+| Solve temperature system        |         2 |     0.121s |      0.14% |
+| Initialization                  |         1 |     0.202s |      0.23% |
+| Postprocessing                  |         2 |     0.421s |      0.49% |
+| Setup dof systems               |         1 |     0.444s |      0.52% |
+| Setup initial conditions        |         1 |     0.277s |      0.32% |
++---------------------------------+-----------+------------+------------+
+

--- a/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_2_3_1
+++ b/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_2_3_1
@@ -1,0 +1,100 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 2.0.0-pre (master, 7a539e8)
+--     . using deal.II 8.5.1 (v8.5.1, 0e5d7e8)
+--     . using Trilinos 12.10.1
+--     . using p4est 1.1.0
+--     . running in OPTIMIZED mode
+--     . running with 2 MPI processes
+-----------------------------------------------------------------------------
+
+Number of active cells: 49,152 (on 4 levels)
+Number of degrees of freedom: 2,080,108 (1,216,710+52,258+405,570+405,570)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+26 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.0181 m/year, 0.0354 m/year
+     Temperature min/avg/max: 1521 K, 1600 K, 1679 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |       326s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         1 |      27.4s |       8.4% |
+| Assemble composition system     |         1 |      7.45s |       2.3% |
+| Assemble temperature system     |         1 |      12.2s |       3.7% |
+| Build Stokes preconditioner     |         1 |      17.3s |       5.3% |
+| Build composition preconditioner|         1 |      1.55s |      0.48% |
+| Build temperature preconditioner|         1 |       1.6s |      0.49% |
+| Solve Stokes system             |         1 |       242s |        74% |
+| Solve composition system        |         1 |     0.136s |         0% |
+| Solve temperature system        |         1 |     0.177s |         0% |
+| Initialization                  |         1 |     0.175s |         0% |
+| Postprocessing                  |         1 |      1.73s |      0.53% |
+| Setup dof systems               |         1 |      1.94s |       0.6% |
+| Setup initial conditions        |         1 |      1.77s |      0.54% |
++---------------------------------+-----------+------------+------------+
+
+*** Timestep 1:  t=1.73827e+06 years
+   Solving temperature system... 12 iterations.
+   Solving C_1 system ... 13 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+24 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.018 m/year, 0.0351 m/year
+     Temperature min/avg/max: 1522 K, 1600 K, 1678 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |       797s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |      60.9s |       7.6% |
+| Assemble composition system     |         2 |      17.8s |       2.2% |
+| Assemble temperature system     |         2 |      27.9s |       3.5% |
+| Build Stokes preconditioner     |         2 |      37.8s |       4.7% |
+| Build composition preconditioner|         2 |      3.22s |       0.4% |
+| Build temperature preconditioner|         2 |      3.31s |      0.41% |
+| Solve Stokes system             |         2 |       625s |        78% |
+| Solve composition system        |         2 |     0.816s |       0.1% |
+| Solve temperature system        |         2 |     0.836s |       0.1% |
+| Initialization                  |         1 |     0.175s |         0% |
+| Postprocessing                  |         2 |      3.37s |      0.42% |
+| Setup dof systems               |         1 |      1.94s |      0.24% |
+| Setup initial conditions        |         1 |      1.77s |      0.22% |
++---------------------------------+-----------+------------+------------+
+
+Termination requested by criterion: end step
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |       797s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |      60.9s |       7.6% |
+| Assemble composition system     |         2 |      17.8s |       2.2% |
+| Assemble temperature system     |         2 |      27.9s |       3.5% |
+| Build Stokes preconditioner     |         2 |      37.8s |       4.7% |
+| Build composition preconditioner|         2 |      3.22s |       0.4% |
+| Build temperature preconditioner|         2 |      3.31s |      0.41% |
+| Solve Stokes system             |         2 |       625s |        78% |
+| Solve composition system        |         2 |     0.816s |       0.1% |
+| Solve temperature system        |         2 |     0.836s |       0.1% |
+| Initialization                  |         1 |     0.175s |         0% |
+| Postprocessing                  |         2 |      3.37s |      0.42% |
+| Setup dof systems               |         1 |      1.94s |      0.24% |
+| Setup initial conditions        |         1 |      1.77s |      0.22% |
++---------------------------------+-----------+------------+------------+
+

--- a/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_3072_5_1
+++ b/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_3072_5_1
@@ -1,0 +1,100 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 2.0.0-pre (master, 7a539e8)
+--     . using deal.II 8.5.1 (v8.5.1, 0e5d7e8)
+--     . using Trilinos 12.10.1
+--     . using p4est 1.1.0
+--     . running in OPTIMIZED mode
+--     . running with 3072 MPI processes
+-----------------------------------------------------------------------------
+
+Number of active cells: 3,145,728 (on 6 levels)
+Number of degrees of freedom: 130,008,460 (76,088,070+3,195,010+25,362,690+25,362,690)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+13 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.0181 m/year, 0.0351 m/year
+     Temperature min/avg/max: 1521 K, 1600 K, 1679 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |        60s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         1 |      1.91s |       3.2% |
+| Assemble composition system     |         1 |      0.75s |       1.3% |
+| Assemble temperature system     |         1 |      1.23s |         2% |
+| Build Stokes preconditioner     |         1 |      8.77s |        15% |
+| Build composition preconditioner|         1 |     0.144s |      0.24% |
+| Build temperature preconditioner|         1 |     0.144s |      0.24% |
+| Solve Stokes system             |         1 |      40.9s |        68% |
+| Solve composition system        |         1 |    0.0741s |      0.12% |
+| Solve temperature system        |         1 |     0.317s |      0.53% |
+| Initialization                  |         1 |     0.298s |       0.5% |
+| Postprocessing                  |         1 |     0.168s |      0.28% |
+| Setup dof systems               |         1 |     0.913s |       1.5% |
+| Setup initial conditions        |         1 |     0.883s |       1.5% |
++---------------------------------+-----------+------------+------------+
+
+*** Timestep 1:  t=450579 years
+   Solving temperature system... 14 iterations.
+   Solving C_1 system ... 17 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+28 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.0182 m/year, 0.0365 m/year
+     Temperature min/avg/max: 1521 K, 1600 K, 1679 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |       190s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |      3.97s |       2.1% |
+| Assemble composition system     |         2 |       1.5s |      0.79% |
+| Assemble temperature system     |         2 |       2.3s |       1.2% |
+| Build Stokes preconditioner     |         2 |      16.6s |       8.7% |
+| Build composition preconditioner|         2 |     0.293s |      0.15% |
+| Build temperature preconditioner|         2 |      0.36s |      0.19% |
+| Solve Stokes system             |         2 |       158s |        83% |
+| Solve composition system        |         2 |     0.222s |      0.12% |
+| Solve temperature system        |         2 |     0.434s |      0.23% |
+| Initialization                  |         1 |     0.298s |      0.16% |
+| Postprocessing                  |         2 |     0.339s |      0.18% |
+| Setup dof systems               |         1 |     0.913s |      0.48% |
+| Setup initial conditions        |         1 |     0.883s |      0.47% |
++---------------------------------+-----------+------------+------------+
+
+Termination requested by criterion: end step
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |       190s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |      3.97s |       2.1% |
+| Assemble composition system     |         2 |       1.5s |      0.79% |
+| Assemble temperature system     |         2 |       2.3s |       1.2% |
+| Build Stokes preconditioner     |         2 |      16.6s |       8.7% |
+| Build composition preconditioner|         2 |     0.293s |      0.15% |
+| Build temperature preconditioner|         2 |      0.36s |      0.19% |
+| Solve Stokes system             |         2 |       158s |        83% |
+| Solve composition system        |         2 |     0.222s |      0.12% |
+| Solve temperature system        |         2 |     0.434s |      0.23% |
+| Initialization                  |         1 |     0.298s |      0.16% |
+| Postprocessing                  |         2 |     0.339s |      0.18% |
+| Setup dof systems               |         1 |     0.913s |      0.48% |
+| Setup initial conditions        |         1 |     0.883s |      0.47% |
++---------------------------------+-----------+------------+------------+
+

--- a/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_3072_6_1
+++ b/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_3072_6_1
@@ -1,0 +1,100 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 2.0.0-pre (master, 7a539e8)
+--     . using deal.II 8.5.1 (v8.5.1, 0e5d7e8)
+--     . using Trilinos 12.10.1
+--     . using p4est 1.1.0
+--     . running in OPTIMIZED mode
+--     . running with 3072 MPI processes
+-----------------------------------------------------------------------------
+
+Number of active cells: 25,165,824 (on 7 levels)
+Number of degrees of freedom: 1,035,930,380 (606,340,614+25,362,690+202,113,538+202,113,538)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+13 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.0181 m/year, 0.0351 m/year
+     Temperature min/avg/max: 1521 K, 1600 K, 1679 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |       316s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         1 |      13.6s |       4.3% |
+| Assemble composition system     |         1 |      4.32s |       1.4% |
+| Assemble temperature system     |         1 |      6.86s |       2.2% |
+| Build Stokes preconditioner     |         1 |      22.9s |       7.3% |
+| Build composition preconditioner|         1 |      0.78s |      0.25% |
+| Build temperature preconditioner|         1 |     0.845s |      0.27% |
+| Solve Stokes system             |         1 |       248s |        78% |
+| Solve composition system        |         1 |     0.387s |      0.12% |
+| Solve temperature system        |         1 |     0.561s |      0.18% |
+| Initialization                  |         1 |     0.309s |         0% |
+| Postprocessing                  |         1 |     0.833s |      0.26% |
+| Setup dof systems               |         1 |      2.49s |      0.79% |
+| Setup initial conditions        |         1 |      2.36s |      0.75% |
++---------------------------------+-----------+------------+------------+
+
+*** Timestep 1:  t=225400 years
+   Solving temperature system... 12 iterations.
+   Solving C_1 system ... 16 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+10 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.0181 m/year, 0.0351 m/year
+     Temperature min/avg/max: 1521 K, 1600 K, 1679 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |       633s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |      28.1s |       4.4% |
+| Assemble composition system     |         2 |      9.27s |       1.5% |
+| Assemble temperature system     |         2 |      14.1s |       2.2% |
+| Build Stokes preconditioner     |         2 |      46.3s |       7.3% |
+| Build composition preconditioner|         2 |      1.53s |      0.24% |
+| Build temperature preconditioner|         2 |      1.59s |      0.25% |
+| Solve Stokes system             |         2 |       509s |        80% |
+| Solve composition system        |         2 |      1.26s |       0.2% |
+| Solve temperature system        |         2 |      1.22s |      0.19% |
+| Initialization                  |         1 |     0.309s |         0% |
+| Postprocessing                  |         2 |      2.06s |      0.33% |
+| Setup dof systems               |         1 |      2.49s |      0.39% |
+| Setup initial conditions        |         1 |      2.36s |      0.37% |
++---------------------------------+-----------+------------+------------+
+
+Termination requested by criterion: end step
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |       633s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |      28.1s |       4.4% |
+| Assemble composition system     |         2 |      9.27s |       1.5% |
+| Assemble temperature system     |         2 |      14.1s |       2.2% |
+| Build Stokes preconditioner     |         2 |      46.3s |       7.3% |
+| Build composition preconditioner|         2 |      1.53s |      0.24% |
+| Build temperature preconditioner|         2 |      1.59s |      0.25% |
+| Solve Stokes system             |         2 |       509s |        80% |
+| Solve composition system        |         2 |      1.26s |       0.2% |
+| Solve temperature system        |         2 |      1.22s |      0.19% |
+| Initialization                  |         1 |     0.309s |         0% |
+| Postprocessing                  |         2 |      2.06s |      0.33% |
+| Setup dof systems               |         1 |      2.49s |      0.39% |
+| Setup initial conditions        |         1 |      2.36s |      0.37% |
++---------------------------------+-----------+------------+------------+
+

--- a/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_384_3_1
+++ b/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_384_3_1
@@ -1,0 +1,100 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 2.0.0-pre (master, 7a539e8)
+--     . using deal.II 8.5.1 (v8.5.1, 0e5d7e8)
+--     . using Trilinos 12.10.1
+--     . using p4est 1.1.0
+--     . running in OPTIMIZED mode
+--     . running with 384 MPI processes
+-----------------------------------------------------------------------------
+
+Number of active cells: 49,152 (on 4 levels)
+Number of degrees of freedom: 2,080,108 (1,216,710+52,258+405,570+405,570)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+26 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.0181 m/year, 0.0359 m/year
+     Temperature min/avg/max: 1521 K, 1600 K, 1679 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      14.9s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         1 |     0.306s |         2% |
+| Assemble composition system     |         1 |     0.101s |      0.68% |
+| Assemble temperature system     |         1 |     0.247s |       1.7% |
+| Build Stokes preconditioner     |         1 |       3.7s |        25% |
+| Build composition preconditioner|         1 |    0.0102s |         0% |
+| Build temperature preconditioner|         1 |    0.0575s |      0.38% |
+| Solve Stokes system             |         1 |      9.28s |        62% |
+| Solve composition system        |         1 |   0.00869s |         0% |
+| Solve temperature system        |         1 |    0.0711s |      0.48% |
+| Initialization                  |         1 |     0.222s |       1.5% |
+| Postprocessing                  |         1 |    0.0332s |      0.22% |
+| Setup dof systems               |         1 |     0.235s |       1.6% |
+| Setup initial conditions        |         1 |     0.149s |         1% |
++---------------------------------+-----------+------------+------------+
+
+*** Timestep 1:  t=1.71358e+06 years
+   Solving temperature system... 16 iterations.
+   Solving C_1 system ... 18 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+24 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.018 m/year, 0.0353 m/year
+     Temperature min/avg/max: 1522 K, 1600 K, 1678 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      34.9s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |     0.604s |       1.7% |
+| Assemble composition system     |         2 |     0.208s |       0.6% |
+| Assemble temperature system     |         2 |     0.395s |       1.1% |
+| Build Stokes preconditioner     |         2 |      7.06s |        20% |
+| Build composition preconditioner|         2 |    0.0203s |         0% |
+| Build temperature preconditioner|         2 |    0.0677s |      0.19% |
+| Solve Stokes system             |         2 |      25.2s |        72% |
+| Solve composition system        |         2 |    0.0386s |      0.11% |
+| Solve temperature system        |         2 |    0.0901s |      0.26% |
+| Initialization                  |         1 |     0.222s |      0.64% |
+| Postprocessing                  |         2 |    0.0482s |      0.14% |
+| Setup dof systems               |         1 |     0.235s |      0.67% |
+| Setup initial conditions        |         1 |     0.149s |      0.43% |
++---------------------------------+-----------+------------+------------+
+
+Termination requested by criterion: end step
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      34.9s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |     0.604s |       1.7% |
+| Assemble composition system     |         2 |     0.208s |       0.6% |
+| Assemble temperature system     |         2 |     0.395s |       1.1% |
+| Build Stokes preconditioner     |         2 |      7.06s |        20% |
+| Build composition preconditioner|         2 |    0.0203s |         0% |
+| Build temperature preconditioner|         2 |    0.0677s |      0.19% |
+| Solve Stokes system             |         2 |      25.2s |        72% |
+| Solve composition system        |         2 |    0.0386s |      0.11% |
+| Solve temperature system        |         2 |    0.0901s |      0.26% |
+| Initialization                  |         1 |     0.222s |      0.64% |
+| Postprocessing                  |         2 |    0.0482s |      0.14% |
+| Setup dof systems               |         1 |     0.235s |      0.67% |
+| Setup initial conditions        |         1 |     0.149s |      0.43% |
++---------------------------------+-----------+------------+------------+
+

--- a/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_384_4_1
+++ b/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_384_4_1
@@ -1,0 +1,100 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 2.0.0-pre (master, 7a539e8)
+--     . using deal.II 8.5.1 (v8.5.1, 0e5d7e8)
+--     . using Trilinos 12.10.1
+--     . using p4est 1.1.0
+--     . running in OPTIMIZED mode
+--     . running with 384 MPI processes
+-----------------------------------------------------------------------------
+
+Number of active cells: 393,216 (on 5 levels)
+Number of degrees of freedom: 16,380,620 (9,585,030+405,570+3,195,010+3,195,010)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+13 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.0181 m/year, 0.0351 m/year
+     Temperature min/avg/max: 1521 K, 1600 K, 1679 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      20.9s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         1 |      1.78s |       8.5% |
+| Assemble composition system     |         1 |      0.62s |         3% |
+| Assemble temperature system     |         1 |      1.01s |       4.8% |
+| Build Stokes preconditioner     |         1 |      1.79s |       8.5% |
+| Build composition preconditioner|         1 |    0.0853s |      0.41% |
+| Build temperature preconditioner|         1 |     0.136s |      0.65% |
+| Solve Stokes system             |         1 |      12.5s |        60% |
+| Solve composition system        |         1 |    0.0364s |      0.17% |
+| Solve temperature system        |         1 |    0.0874s |      0.42% |
+| Initialization                  |         1 |     0.237s |       1.1% |
+| Postprocessing                  |         1 |     0.107s |      0.51% |
+| Setup dof systems               |         1 |      0.46s |       2.2% |
+| Setup initial conditions        |         1 |     0.344s |       1.6% |
++---------------------------------+-----------+------------+------------+
+
+*** Timestep 1:  t=900165 years
+   Solving temperature system... 15 iterations.
+   Solving C_1 system ... 17 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+26 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.0181 m/year, 0.035 m/year
+     Temperature min/avg/max: 1521 K, 1600 K, 1679 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      64.8s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |      3.67s |       5.7% |
+| Assemble composition system     |         2 |      1.28s |         2% |
+| Assemble temperature system     |         2 |      1.96s |         3% |
+| Build Stokes preconditioner     |         2 |      3.33s |       5.1% |
+| Build composition preconditioner|         2 |     0.305s |      0.47% |
+| Build temperature preconditioner|         2 |     0.307s |      0.47% |
+| Solve Stokes system             |         2 |      50.6s |        78% |
+| Solve composition system        |         2 |     0.137s |      0.21% |
+| Solve temperature system        |         2 |     0.182s |      0.28% |
+| Initialization                  |         1 |     0.237s |      0.37% |
+| Postprocessing                  |         2 |     0.199s |      0.31% |
+| Setup dof systems               |         1 |      0.46s |      0.71% |
+| Setup initial conditions        |         1 |     0.344s |      0.53% |
++---------------------------------+-----------+------------+------------+
+
+Termination requested by criterion: end step
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      64.8s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |      3.67s |       5.7% |
+| Assemble composition system     |         2 |      1.28s |         2% |
+| Assemble temperature system     |         2 |      1.96s |         3% |
+| Build Stokes preconditioner     |         2 |      3.33s |       5.1% |
+| Build composition preconditioner|         2 |     0.305s |      0.47% |
+| Build temperature preconditioner|         2 |     0.307s |      0.47% |
+| Solve Stokes system             |         2 |      50.6s |        78% |
+| Solve composition system        |         2 |     0.137s |      0.21% |
+| Solve temperature system        |         2 |     0.182s |      0.28% |
+| Initialization                  |         1 |     0.237s |      0.37% |
+| Postprocessing                  |         2 |     0.199s |      0.31% |
+| Setup dof systems               |         1 |      0.46s |      0.71% |
+| Setup initial conditions        |         1 |     0.344s |      0.53% |
++---------------------------------+-----------+------------+------------+
+

--- a/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_384_5_1
+++ b/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_384_5_1
@@ -1,0 +1,100 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 2.0.0-pre (master, 7a539e8)
+--     . using deal.II 8.5.1 (v8.5.1, 0e5d7e8)
+--     . using Trilinos 12.10.1
+--     . using p4est 1.1.0
+--     . running in OPTIMIZED mode
+--     . running with 384 MPI processes
+-----------------------------------------------------------------------------
+
+Number of active cells: 3,145,728 (on 6 levels)
+Number of degrees of freedom: 130,008,460 (76,088,070+3,195,010+25,362,690+25,362,690)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+13 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.0181 m/year, 0.0351 m/year
+     Temperature min/avg/max: 1521 K, 1600 K, 1679 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |       139s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         1 |      13.4s |       9.6% |
+| Assemble composition system     |         1 |      3.97s |       2.8% |
+| Assemble temperature system     |         1 |      6.16s |       4.4% |
+| Build Stokes preconditioner     |         1 |       9.7s |         7% |
+| Build composition preconditioner|         1 |     0.767s |      0.55% |
+| Build temperature preconditioner|         1 |     0.747s |      0.54% |
+| Solve Stokes system             |         1 |        92s |        66% |
+| Solve composition system        |         1 |      0.24s |      0.17% |
+| Solve temperature system        |         1 |     0.173s |      0.12% |
+| Initialization                  |         1 |     0.231s |      0.17% |
+| Postprocessing                  |         1 |     0.723s |      0.52% |
+| Setup dof systems               |         1 |      1.81s |       1.3% |
+| Setup initial conditions        |         1 |      1.17s |      0.84% |
++---------------------------------+-----------+------------+------------+
+
+*** Timestep 1:  t=450082 years
+   Solving temperature system... 13 iterations.
+   Solving C_1 system ... 16 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+28 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.0181 m/year, 0.0353 m/year
+     Temperature min/avg/max: 1521 K, 1600 K, 1679 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |       478s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |      27.6s |       5.8% |
+| Assemble composition system     |         2 |      8.66s |       1.8% |
+| Assemble temperature system     |         2 |      13.2s |       2.7% |
+| Build Stokes preconditioner     |         2 |      19.7s |       4.1% |
+| Build composition preconditioner|         2 |      1.49s |      0.31% |
+| Build temperature preconditioner|         2 |      1.48s |      0.31% |
+| Solve Stokes system             |         2 |       391s |        82% |
+| Solve composition system        |         2 |      1.01s |      0.21% |
+| Solve temperature system        |         2 |     0.809s |      0.17% |
+| Initialization                  |         1 |     0.231s |         0% |
+| Postprocessing                  |         2 |      1.45s |       0.3% |
+| Setup dof systems               |         1 |      1.81s |      0.38% |
+| Setup initial conditions        |         1 |      1.17s |      0.24% |
++---------------------------------+-----------+------------+------------+
+
+Termination requested by criterion: end step
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |       478s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |      27.6s |       5.8% |
+| Assemble composition system     |         2 |      8.66s |       1.8% |
+| Assemble temperature system     |         2 |      13.2s |       2.7% |
+| Build Stokes preconditioner     |         2 |      19.7s |       4.1% |
+| Build composition preconditioner|         2 |      1.49s |      0.31% |
+| Build temperature preconditioner|         2 |      1.48s |      0.31% |
+| Solve Stokes system             |         2 |       391s |        82% |
+| Solve composition system        |         2 |      1.01s |      0.21% |
+| Solve temperature system        |         2 |     0.809s |      0.17% |
+| Initialization                  |         1 |     0.231s |         0% |
+| Postprocessing                  |         2 |      1.45s |       0.3% |
+| Setup dof systems               |         1 |      1.81s |      0.38% |
+| Setup initial conditions        |         1 |      1.17s |      0.24% |
++---------------------------------+-----------+------------+------------+
+

--- a/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_3_2_1
+++ b/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_3_2_1
@@ -1,0 +1,100 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 2.0.0-pre (master, 7a539e8)
+--     . using deal.II 8.5.1 (v8.5.1, 0e5d7e8)
+--     . using Trilinos 12.10.1
+--     . using p4est 1.1.0
+--     . running in OPTIMIZED mode
+--     . running with 3 MPI processes
+-----------------------------------------------------------------------------
+
+Number of active cells: 6,144 (on 3 levels)
+Number of degrees of freedom: 268,220 (156,774+6,930+52,258+52,258)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+24 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.0181 m/year, 0.0426 m/year
+     Temperature min/avg/max: 1522 K, 1600 K, 1678 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      25.2s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         1 |      2.48s |       9.8% |
+| Assemble composition system     |         1 |     0.689s |       2.7% |
+| Assemble temperature system     |         1 |      1.13s |       4.5% |
+| Build Stokes preconditioner     |         1 |      1.66s |       6.6% |
+| Build composition preconditioner|         1 |     0.126s |       0.5% |
+| Build temperature preconditioner|         1 |     0.146s |      0.58% |
+| Solve Stokes system             |         1 |      16.8s |        66% |
+| Solve composition system        |         1 |    0.0139s |         0% |
+| Solve temperature system        |         1 |    0.0426s |      0.17% |
+| Initialization                  |         1 |     0.229s |      0.91% |
+| Postprocessing                  |         1 |     0.141s |      0.56% |
+| Setup dof systems               |         1 |     0.389s |       1.5% |
+| Setup initial conditions        |         1 |     0.216s |      0.86% |
++---------------------------------+-----------+------------+------------+
+
+*** Timestep 1:  t=2.25373e+06 years
+   Solving temperature system... 12 iterations.
+   Solving C_1 system ... 14 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+22 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.018 m/year, 0.0423 m/year
+     Temperature min/avg/max: 1523 K, 1600 K, 1678 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      55.2s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |      5.02s |       9.1% |
+| Assemble composition system     |         2 |       1.5s |       2.7% |
+| Assemble temperature system     |         2 |      2.32s |       4.2% |
+| Build Stokes preconditioner     |         2 |      3.29s |         6% |
+| Build composition preconditioner|         2 |     0.248s |      0.45% |
+| Build temperature preconditioner|         2 |      0.27s |      0.49% |
+| Solve Stokes system             |         2 |      39.9s |        72% |
+| Solve composition system        |         2 |    0.0708s |      0.13% |
+| Solve temperature system        |         2 |    0.0926s |      0.17% |
+| Initialization                  |         1 |     0.229s |      0.41% |
+| Postprocessing                  |         2 |     0.278s |       0.5% |
+| Setup dof systems               |         1 |     0.389s |       0.7% |
+| Setup initial conditions        |         1 |     0.216s |      0.39% |
++---------------------------------+-----------+------------+------------+
+
+Termination requested by criterion: end step
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      55.2s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |      5.02s |       9.1% |
+| Assemble composition system     |         2 |       1.5s |       2.7% |
+| Assemble temperature system     |         2 |      2.32s |       4.2% |
+| Build Stokes preconditioner     |         2 |      3.29s |         6% |
+| Build composition preconditioner|         2 |     0.248s |      0.45% |
+| Build temperature preconditioner|         2 |      0.27s |      0.49% |
+| Solve Stokes system             |         2 |      39.9s |        72% |
+| Solve composition system        |         2 |    0.0708s |      0.13% |
+| Solve temperature system        |         2 |    0.0926s |      0.17% |
+| Initialization                  |         1 |     0.229s |      0.41% |
+| Postprocessing                  |         2 |     0.278s |       0.5% |
+| Setup dof systems               |         1 |     0.389s |       0.7% |
+| Setup initial conditions        |         1 |     0.216s |      0.39% |
++---------------------------------+-----------+------------+------------+
+

--- a/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_3_3_1
+++ b/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_3_3_1
@@ -1,0 +1,100 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 2.0.0-pre (master, 7a539e8)
+--     . using deal.II 8.5.1 (v8.5.1, 0e5d7e8)
+--     . using Trilinos 12.10.1
+--     . using p4est 1.1.0
+--     . running in OPTIMIZED mode
+--     . running with 3 MPI processes
+-----------------------------------------------------------------------------
+
+Number of active cells: 49,152 (on 4 levels)
+Number of degrees of freedom: 2,080,108 (1,216,710+52,258+405,570+405,570)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+26 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.0182 m/year, 0.0371 m/year
+     Temperature min/avg/max: 1521 K, 1600 K, 1679 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |       240s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         1 |        19s |       7.9% |
+| Assemble composition system     |         1 |      5.18s |       2.2% |
+| Assemble temperature system     |         1 |      8.44s |       3.5% |
+| Build Stokes preconditioner     |         1 |      12.3s |       5.1% |
+| Build composition preconditioner|         1 |      1.05s |      0.44% |
+| Build temperature preconditioner|         1 |      1.08s |      0.45% |
+| Solve Stokes system             |         1 |       180s |        75% |
+| Solve composition system        |         1 |     0.109s |         0% |
+| Solve temperature system        |         1 |     0.132s |         0% |
+| Initialization                  |         1 |     0.179s |         0% |
+| Postprocessing                  |         1 |      1.01s |      0.42% |
+| Setup dof systems               |         1 |      1.54s |      0.64% |
+| Setup initial conditions        |         1 |      1.28s |      0.53% |
++---------------------------------+-----------+------------+------------+
+
+*** Timestep 1:  t=1.66419e+06 years
+   Solving temperature system... 13 iterations.
+   Solving C_1 system ... 14 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+23 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.018 m/year, 0.0351 m/year
+     Temperature min/avg/max: 1522 K, 1600 K, 1678 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |       575s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |      39.2s |       6.8% |
+| Assemble composition system     |         2 |      11.4s |         2% |
+| Assemble temperature system     |         2 |      17.9s |       3.1% |
+| Build Stokes preconditioner     |         2 |      24.8s |       4.3% |
+| Build composition preconditioner|         2 |      2.04s |      0.36% |
+| Build temperature preconditioner|         2 |      2.13s |      0.37% |
+| Solve Stokes system             |         2 |       462s |        80% |
+| Solve composition system        |         2 |     0.632s |      0.11% |
+| Solve temperature system        |         2 |     0.597s |       0.1% |
+| Initialization                  |         1 |     0.179s |         0% |
+| Postprocessing                  |         2 |       2.1s |      0.36% |
+| Setup dof systems               |         1 |      1.54s |      0.27% |
+| Setup initial conditions        |         1 |      1.28s |      0.22% |
++---------------------------------+-----------+------------+------------+
+
+Termination requested by criterion: end step
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |       575s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |      39.2s |       6.8% |
+| Assemble composition system     |         2 |      11.4s |         2% |
+| Assemble temperature system     |         2 |      17.9s |       3.1% |
+| Build Stokes preconditioner     |         2 |      24.8s |       4.3% |
+| Build composition preconditioner|         2 |      2.04s |      0.36% |
+| Build temperature preconditioner|         2 |      2.13s |      0.37% |
+| Solve Stokes system             |         2 |       462s |        80% |
+| Solve composition system        |         2 |     0.632s |      0.11% |
+| Solve temperature system        |         2 |     0.597s |       0.1% |
+| Initialization                  |         1 |     0.179s |         0% |
+| Postprocessing                  |         2 |       2.1s |      0.36% |
+| Setup dof systems               |         1 |      1.54s |      0.27% |
+| Setup initial conditions        |         1 |      1.28s |      0.22% |
++---------------------------------+-----------+------------+------------+
+

--- a/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_48_2_1
+++ b/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_48_2_1
@@ -1,0 +1,100 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 2.0.0-pre (master, 7a539e8)
+--     . using deal.II 8.5.1 (v8.5.1, 0e5d7e8)
+--     . using Trilinos 12.10.1
+--     . using p4est 1.1.0
+--     . running in OPTIMIZED mode
+--     . running with 48 MPI processes
+-----------------------------------------------------------------------------
+
+Number of active cells: 6,144 (on 3 levels)
+Number of degrees of freedom: 268,220 (156,774+6,930+52,258+52,258)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+25 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.0181 m/year, 0.0426 m/year
+     Temperature min/avg/max: 1522 K, 1600 K, 1678 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      4.83s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         1 |     0.259s |       5.4% |
+| Assemble composition system     |         1 |     0.106s |       2.2% |
+| Assemble temperature system     |         1 |     0.138s |       2.9% |
+| Build Stokes preconditioner     |         1 |     0.408s |       8.5% |
+| Build composition preconditioner|         1 |    0.0435s |       0.9% |
+| Build temperature preconditioner|         1 |    0.0559s |       1.2% |
+| Solve Stokes system             |         1 |      2.89s |        60% |
+| Solve composition system        |         1 |   0.00348s |         0% |
+| Solve temperature system        |         1 |    0.0406s |      0.84% |
+| Initialization                  |         1 |     0.242s |         5% |
+| Postprocessing                  |         1 |    0.0196s |      0.41% |
+| Setup dof systems               |         1 |     0.224s |       4.6% |
+| Setup initial conditions        |         1 |    0.0718s |       1.5% |
++---------------------------------+-----------+------------+------------+
+
+*** Timestep 1:  t=2.25407e+06 years
+   Solving temperature system... 15 iterations.
+   Solving C_1 system ... 17 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+23 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.018 m/year, 0.0423 m/year
+     Temperature min/avg/max: 1523 K, 1600 K, 1678 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      8.44s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |      0.51s |         6% |
+| Assemble composition system     |         2 |     0.194s |       2.3% |
+| Assemble temperature system     |         2 |     0.262s |       3.1% |
+| Build Stokes preconditioner     |         2 |     0.612s |       7.3% |
+| Build composition preconditioner|         2 |    0.0537s |      0.64% |
+| Build temperature preconditioner|         2 |     0.066s |      0.78% |
+| Solve Stokes system             |         2 |      5.78s |        68% |
+| Solve composition system        |         2 |    0.0133s |      0.16% |
+| Solve temperature system        |         2 |    0.0497s |      0.59% |
+| Initialization                  |         1 |     0.242s |       2.9% |
+| Postprocessing                  |         2 |    0.0341s |       0.4% |
+| Setup dof systems               |         1 |     0.224s |       2.7% |
+| Setup initial conditions        |         1 |    0.0718s |      0.85% |
++---------------------------------+-----------+------------+------------+
+
+Termination requested by criterion: end step
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      8.44s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |      0.51s |         6% |
+| Assemble composition system     |         2 |     0.194s |       2.3% |
+| Assemble temperature system     |         2 |     0.262s |       3.1% |
+| Build Stokes preconditioner     |         2 |     0.612s |       7.3% |
+| Build composition preconditioner|         2 |    0.0537s |      0.64% |
+| Build temperature preconditioner|         2 |     0.066s |      0.78% |
+| Solve Stokes system             |         2 |      5.78s |        68% |
+| Solve composition system        |         2 |    0.0133s |      0.16% |
+| Solve temperature system        |         2 |    0.0497s |      0.59% |
+| Initialization                  |         1 |     0.242s |       2.9% |
+| Postprocessing                  |         2 |    0.0341s |       0.4% |
+| Setup dof systems               |         1 |     0.224s |       2.7% |
+| Setup initial conditions        |         1 |    0.0718s |      0.85% |
++---------------------------------+-----------+------------+------------+
+

--- a/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_48_3_1
+++ b/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_48_3_1
@@ -1,0 +1,100 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 2.0.0-pre (master, 7a539e8)
+--     . using deal.II 8.5.1 (v8.5.1, 0e5d7e8)
+--     . using Trilinos 12.10.1
+--     . using p4est 1.1.0
+--     . running in OPTIMIZED mode
+--     . running with 48 MPI processes
+-----------------------------------------------------------------------------
+
+Number of active cells: 49,152 (on 4 levels)
+Number of degrees of freedom: 2,080,108 (1,216,710+52,258+405,570+405,570)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+26 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.0181 m/year, 0.0358 m/year
+     Temperature min/avg/max: 1521 K, 1600 K, 1679 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      29.8s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         1 |       1.7s |       5.7% |
+| Assemble composition system     |         1 |     0.532s |       1.8% |
+| Assemble temperature system     |         1 |     0.841s |       2.8% |
+| Build Stokes preconditioner     |         1 |      1.37s |       4.6% |
+| Build composition preconditioner|         1 |     0.088s |       0.3% |
+| Build temperature preconditioner|         1 |     0.124s |      0.42% |
+| Solve Stokes system             |         1 |      23.1s |        77% |
+| Solve composition system        |         1 |    0.0139s |         0% |
+| Solve temperature system        |         1 |    0.0485s |      0.16% |
+| Initialization                  |         1 |     0.204s |      0.69% |
+| Postprocessing                  |         1 |     0.115s |      0.38% |
+| Setup dof systems               |         1 |     0.367s |       1.2% |
+| Setup initial conditions        |         1 |     0.165s |      0.55% |
++---------------------------------+-----------+------------+------------+
+
+*** Timestep 1:  t=1.71782e+06 years
+   Solving temperature system... 15 iterations.
+   Solving C_1 system ... 16 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+24 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.018 m/year, 0.0351 m/year
+     Temperature min/avg/max: 1522 K, 1600 K, 1678 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      75.2s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |      3.49s |       4.6% |
+| Assemble composition system     |         2 |      1.12s |       1.5% |
+| Assemble temperature system     |         2 |      1.74s |       2.3% |
+| Build Stokes preconditioner     |         2 |      2.57s |       3.4% |
+| Build composition preconditioner|         2 |     0.173s |      0.23% |
+| Build temperature preconditioner|         2 |      0.21s |      0.28% |
+| Solve Stokes system             |         2 |      63.5s |        84% |
+| Solve composition system        |         2 |    0.0835s |      0.11% |
+| Solve temperature system        |         2 |     0.114s |      0.15% |
+| Initialization                  |         1 |     0.204s |      0.27% |
+| Postprocessing                  |         2 |     0.203s |      0.27% |
+| Setup dof systems               |         1 |     0.367s |      0.49% |
+| Setup initial conditions        |         1 |     0.165s |      0.22% |
++---------------------------------+-----------+------------+------------+
+
+Termination requested by criterion: end step
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      75.2s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |      3.49s |       4.6% |
+| Assemble composition system     |         2 |      1.12s |       1.5% |
+| Assemble temperature system     |         2 |      1.74s |       2.3% |
+| Build Stokes preconditioner     |         2 |      2.57s |       3.4% |
+| Build composition preconditioner|         2 |     0.173s |      0.23% |
+| Build temperature preconditioner|         2 |      0.21s |      0.28% |
+| Solve Stokes system             |         2 |      63.5s |        84% |
+| Solve composition system        |         2 |    0.0835s |      0.11% |
+| Solve temperature system        |         2 |     0.114s |      0.15% |
+| Initialization                  |         1 |     0.204s |      0.27% |
+| Postprocessing                  |         2 |     0.203s |      0.27% |
+| Setup dof systems               |         1 |     0.367s |      0.49% |
+| Setup initial conditions        |         1 |     0.165s |      0.22% |
++---------------------------------+-----------+------------+------------+
+

--- a/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_48_4_1
+++ b/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_48_4_1
@@ -1,0 +1,100 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 2.0.0-pre (master, 7a539e8)
+--     . using deal.II 8.5.1 (v8.5.1, 0e5d7e8)
+--     . using Trilinos 12.10.1
+--     . using p4est 1.1.0
+--     . running in OPTIMIZED mode
+--     . running with 48 MPI processes
+-----------------------------------------------------------------------------
+
+Number of active cells: 393,216 (on 5 levels)
+Number of degrees of freedom: 16,380,620 (9,585,030+405,570+3,195,010+3,195,010)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+13 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.0181 m/year, 0.0352 m/year
+     Temperature min/avg/max: 1521 K, 1600 K, 1679 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |       115s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         1 |        13s |        11% |
+| Assemble composition system     |         1 |       3.6s |       3.1% |
+| Assemble temperature system     |         1 |      5.87s |       5.1% |
+| Build Stokes preconditioner     |         1 |      8.98s |       7.8% |
+| Build composition preconditioner|         1 |     0.725s |      0.63% |
+| Build temperature preconditioner|         1 |     0.753s |      0.65% |
+| Solve Stokes system             |         1 |      72.2s |        63% |
+| Solve composition system        |         1 |      0.15s |      0.13% |
+| Solve temperature system        |         1 |     0.139s |      0.12% |
+| Initialization                  |         1 |       0.2s |      0.17% |
+| Postprocessing                  |         1 |      0.69s |       0.6% |
+| Setup dof systems               |         1 |      1.33s |       1.2% |
+| Setup initial conditions        |         1 |     0.943s |      0.82% |
++---------------------------------+-----------+------------+------------+
+
+*** Timestep 1:  t=898227 years
+   Solving temperature system... 13 iterations.
+   Solving C_1 system ... 15 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+26 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.0181 m/year, 0.0353 m/year
+     Temperature min/avg/max: 1521 K, 1600 K, 1679 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |       386s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |      26.8s |       6.9% |
+| Assemble composition system     |         2 |      7.97s |       2.1% |
+| Assemble temperature system     |         2 |      12.4s |       3.2% |
+| Build Stokes preconditioner     |         2 |      18.1s |       4.7% |
+| Build composition preconditioner|         2 |      1.46s |      0.38% |
+| Build temperature preconditioner|         2 |      1.48s |      0.38% |
+| Solve Stokes system             |         2 |       306s |        79% |
+| Solve composition system        |         2 |      0.69s |      0.18% |
+| Solve temperature system        |         2 |     0.615s |      0.16% |
+| Initialization                  |         1 |       0.2s |         0% |
+| Postprocessing                  |         2 |      1.38s |      0.36% |
+| Setup dof systems               |         1 |      1.33s |      0.34% |
+| Setup initial conditions        |         1 |     0.943s |      0.24% |
++---------------------------------+-----------+------------+------------+
+
+Termination requested by criterion: end step
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |       386s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |      26.8s |       6.9% |
+| Assemble composition system     |         2 |      7.97s |       2.1% |
+| Assemble temperature system     |         2 |      12.4s |       3.2% |
+| Build Stokes preconditioner     |         2 |      18.1s |       4.7% |
+| Build composition preconditioner|         2 |      1.46s |      0.38% |
+| Build temperature preconditioner|         2 |      1.48s |      0.38% |
+| Solve Stokes system             |         2 |       306s |        79% |
+| Solve composition system        |         2 |      0.69s |      0.18% |
+| Solve temperature system        |         2 |     0.615s |      0.16% |
+| Initialization                  |         1 |       0.2s |         0% |
+| Postprocessing                  |         2 |      1.38s |      0.36% |
+| Setup dof systems               |         1 |      1.33s |      0.34% |
+| Setup initial conditions        |         1 |     0.943s |      0.24% |
++---------------------------------+-----------+------------+------------+
+

--- a/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_4_2_1
+++ b/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_4_2_1
@@ -1,0 +1,100 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 2.0.0-pre (master, 7a539e8)
+--     . using deal.II 8.5.1 (v8.5.1, 0e5d7e8)
+--     . using Trilinos 12.10.1
+--     . using p4est 1.1.0
+--     . running in OPTIMIZED mode
+--     . running with 4 MPI processes
+-----------------------------------------------------------------------------
+
+Number of active cells: 6,144 (on 3 levels)
+Number of degrees of freedom: 268,220 (156,774+6,930+52,258+52,258)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+24 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.0181 m/year, 0.0427 m/year
+     Temperature min/avg/max: 1522 K, 1600 K, 1678 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      19.8s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         1 |      1.89s |       9.6% |
+| Assemble composition system     |         1 |     0.529s |       2.7% |
+| Assemble temperature system     |         1 |     0.871s |       4.4% |
+| Build Stokes preconditioner     |         1 |      1.37s |       6.9% |
+| Build composition preconditioner|         1 |    0.0958s |      0.48% |
+| Build temperature preconditioner|         1 |      0.12s |      0.61% |
+| Solve Stokes system             |         1 |      13.2s |        67% |
+| Solve composition system        |         1 |    0.0107s |         0% |
+| Solve temperature system        |         1 |    0.0392s |       0.2% |
+| Initialization                  |         1 |     0.187s |      0.95% |
+| Postprocessing                  |         1 |     0.112s |      0.57% |
+| Setup dof systems               |         1 |     0.243s |       1.2% |
+| Setup initial conditions        |         1 |     0.158s |       0.8% |
++---------------------------------+-----------+------------+------------+
+
+*** Timestep 1:  t=2.25169e+06 years
+   Solving temperature system... 13 iterations.
+   Solving C_1 system ... 14 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+23 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.018 m/year, 0.0423 m/year
+     Temperature min/avg/max: 1523 K, 1600 K, 1678 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      44.6s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |      3.82s |       8.6% |
+| Assemble composition system     |         2 |      1.15s |       2.6% |
+| Assemble temperature system     |         2 |       1.8s |         4% |
+| Build Stokes preconditioner     |         2 |      2.64s |       5.9% |
+| Build composition preconditioner|         2 |     0.191s |      0.43% |
+| Build temperature preconditioner|         2 |     0.216s |      0.48% |
+| Solve Stokes system             |         2 |      32.8s |        74% |
+| Solve composition system        |         2 |    0.0548s |      0.12% |
+| Solve temperature system        |         2 |    0.0816s |      0.18% |
+| Initialization                  |         1 |     0.187s |      0.42% |
+| Postprocessing                  |         2 |     0.221s |       0.5% |
+| Setup dof systems               |         1 |     0.243s |      0.54% |
+| Setup initial conditions        |         1 |     0.158s |      0.35% |
++---------------------------------+-----------+------------+------------+
+
+Termination requested by criterion: end step
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      44.6s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |      3.82s |       8.6% |
+| Assemble composition system     |         2 |      1.15s |       2.6% |
+| Assemble temperature system     |         2 |       1.8s |         4% |
+| Build Stokes preconditioner     |         2 |      2.64s |       5.9% |
+| Build composition preconditioner|         2 |     0.191s |      0.43% |
+| Build temperature preconditioner|         2 |     0.216s |      0.48% |
+| Solve Stokes system             |         2 |      32.8s |        74% |
+| Solve composition system        |         2 |    0.0548s |      0.12% |
+| Solve temperature system        |         2 |    0.0816s |      0.18% |
+| Initialization                  |         1 |     0.187s |      0.42% |
+| Postprocessing                  |         2 |     0.221s |       0.5% |
+| Setup dof systems               |         1 |     0.243s |      0.54% |
+| Setup initial conditions        |         1 |     0.158s |      0.35% |
++---------------------------------+-----------+------------+------------+
+

--- a/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_4_3_1
+++ b/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_4_3_1
@@ -1,0 +1,100 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 2.0.0-pre (master, 7a539e8)
+--     . using deal.II 8.5.1 (v8.5.1, 0e5d7e8)
+--     . using Trilinos 12.10.1
+--     . using p4est 1.1.0
+--     . running in OPTIMIZED mode
+--     . running with 4 MPI processes
+-----------------------------------------------------------------------------
+
+Number of active cells: 49,152 (on 4 levels)
+Number of degrees of freedom: 2,080,108 (1,216,710+52,258+405,570+405,570)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+26 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.0183 m/year, 0.0373 m/year
+     Temperature min/avg/max: 1521 K, 1600 K, 1679 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |       168s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         1 |      14.6s |       8.7% |
+| Assemble composition system     |         1 |      3.88s |       2.3% |
+| Assemble temperature system     |         1 |      6.42s |       3.8% |
+| Build Stokes preconditioner     |         1 |      9.79s |       5.8% |
+| Build composition preconditioner|         1 |     0.793s |      0.47% |
+| Build temperature preconditioner|         1 |     0.807s |      0.48% |
+| Solve Stokes system             |         1 |       122s |        73% |
+| Solve composition system        |         1 |    0.0773s |         0% |
+| Solve temperature system        |         1 |     0.109s |         0% |
+| Initialization                  |         1 |     0.201s |      0.12% |
+| Postprocessing                  |         1 |     0.793s |      0.47% |
+| Setup dof systems               |         1 |      1.31s |      0.78% |
+| Setup initial conditions        |         1 |     0.966s |      0.58% |
++---------------------------------+-----------+------------+------------+
+
+*** Timestep 1:  t=1.6586e+06 years
+   Solving temperature system... 13 iterations.
+   Solving C_1 system ... 14 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+24 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.018 m/year, 0.0352 m/year
+     Temperature min/avg/max: 1522 K, 1600 K, 1678 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |       436s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |      30.4s |         7% |
+| Assemble composition system     |         2 |      8.74s |         2% |
+| Assemble temperature system     |         2 |      13.7s |       3.2% |
+| Build Stokes preconditioner     |         2 |      19.8s |       4.6% |
+| Build composition preconditioner|         2 |      1.57s |      0.36% |
+| Build temperature preconditioner|         2 |       1.6s |      0.37% |
+| Solve Stokes system             |         2 |       348s |        80% |
+| Solve composition system        |         2 |     0.442s |       0.1% |
+| Solve temperature system        |         2 |     0.461s |      0.11% |
+| Initialization                  |         1 |     0.201s |         0% |
+| Postprocessing                  |         2 |       1.6s |      0.37% |
+| Setup dof systems               |         1 |      1.31s |       0.3% |
+| Setup initial conditions        |         1 |     0.966s |      0.22% |
++---------------------------------+-----------+------------+------------+
+
+Termination requested by criterion: end step
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |       436s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |      30.4s |         7% |
+| Assemble composition system     |         2 |      8.74s |         2% |
+| Assemble temperature system     |         2 |      13.7s |       3.2% |
+| Build Stokes preconditioner     |         2 |      19.8s |       4.6% |
+| Build composition preconditioner|         2 |      1.57s |      0.36% |
+| Build temperature preconditioner|         2 |       1.6s |      0.37% |
+| Solve Stokes system             |         2 |       348s |        80% |
+| Solve composition system        |         2 |     0.442s |       0.1% |
+| Solve temperature system        |         2 |     0.461s |      0.11% |
+| Initialization                  |         1 |     0.201s |         0% |
+| Postprocessing                  |         2 |       1.6s |      0.37% |
+| Setup dof systems               |         1 |      1.31s |       0.3% |
+| Setup initial conditions        |         1 |     0.966s |      0.22% |
++---------------------------------+-----------+------------+------------+
+

--- a/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_6144_5_1
+++ b/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_6144_5_1
@@ -1,0 +1,100 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 2.0.0-pre (master, 7a539e8)
+--     . using deal.II 8.5.1 (v8.5.1, 0e5d7e8)
+--     . using Trilinos 12.10.1
+--     . using p4est 1.1.0
+--     . running in OPTIMIZED mode
+--     . running with 6144 MPI processes
+-----------------------------------------------------------------------------
+
+Number of active cells: 3,145,728 (on 6 levels)
+Number of degrees of freedom: 130,008,460 (76,088,070+3,195,010+25,362,690+25,362,690)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+13 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.0181 m/year, 0.0351 m/year
+     Temperature min/avg/max: 1521 K, 1600 K, 1679 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |        88s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         1 |      1.11s |       1.3% |
+| Assemble composition system     |         1 |     0.508s |      0.58% |
+| Assemble temperature system     |         1 |      1.11s |       1.3% |
+| Build Stokes preconditioner     |         1 |      38.5s |        44% |
+| Build composition preconditioner|         1 |     0.166s |      0.19% |
+| Build temperature preconditioner|         1 |      0.13s |      0.15% |
+| Solve Stokes system             |         1 |      38.5s |        44% |
+| Solve composition system        |         1 |    0.0619s |         0% |
+| Solve temperature system        |         1 |     0.633s |      0.72% |
+| Initialization                  |         1 |     0.426s |      0.48% |
+| Postprocessing                  |         1 |     0.218s |      0.25% |
+| Setup dof systems               |         1 |      1.33s |       1.5% |
+| Setup initial conditions        |         1 |      1.57s |       1.8% |
++---------------------------------+-----------+------------+------------+
+
+*** Timestep 1:  t=450220 years
+   Solving temperature system... 14 iterations.
+   Solving C_1 system ... 17 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+28 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.0182 m/year, 0.0365 m/year
+     Temperature min/avg/max: 1521 K, 1600 K, 1679 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |       243s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |      2.27s |      0.93% |
+| Assemble composition system     |         2 |      1.01s |      0.42% |
+| Assemble temperature system     |         2 |      1.72s |      0.71% |
+| Build Stokes preconditioner     |         2 |      75.8s |        31% |
+| Build composition preconditioner|         2 |     0.328s |      0.14% |
+| Build temperature preconditioner|         2 |     0.283s |      0.12% |
+| Solve Stokes system             |         2 |       153s |        63% |
+| Solve composition system        |         2 |     0.199s |         0% |
+| Solve temperature system        |         2 |     0.733s |       0.3% |
+| Initialization                  |         1 |     0.426s |      0.18% |
+| Postprocessing                  |         2 |     0.313s |      0.13% |
+| Setup dof systems               |         1 |      1.33s |      0.55% |
+| Setup initial conditions        |         1 |      1.57s |      0.64% |
++---------------------------------+-----------+------------+------------+
+
+Termination requested by criterion: end step
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |       243s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |      2.27s |      0.93% |
+| Assemble composition system     |         2 |      1.01s |      0.42% |
+| Assemble temperature system     |         2 |      1.72s |      0.71% |
+| Build Stokes preconditioner     |         2 |      75.8s |        31% |
+| Build composition preconditioner|         2 |     0.328s |      0.14% |
+| Build temperature preconditioner|         2 |     0.283s |      0.12% |
+| Solve Stokes system             |         2 |       153s |        63% |
+| Solve composition system        |         2 |     0.199s |         0% |
+| Solve temperature system        |         2 |     0.733s |       0.3% |
+| Initialization                  |         1 |     0.426s |      0.18% |
+| Postprocessing                  |         2 |     0.313s |      0.13% |
+| Setup dof systems               |         1 |      1.33s |      0.55% |
+| Setup initial conditions        |         1 |      1.57s |      0.64% |
++---------------------------------+-----------+------------+------------+
+

--- a/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_6144_6_1
+++ b/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_6144_6_1
@@ -1,0 +1,100 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 2.0.0-pre (master, 7a539e8)
+--     . using deal.II 8.5.1 (v8.5.1, 0e5d7e8)
+--     . using Trilinos 12.10.1
+--     . using p4est 1.1.0
+--     . running in OPTIMIZED mode
+--     . running with 6144 MPI processes
+-----------------------------------------------------------------------------
+
+Number of active cells: 25,165,824 (on 7 levels)
+Number of degrees of freedom: 1,035,930,380 (606,340,614+25,362,690+202,113,538+202,113,538)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+13 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.0181 m/year, 0.0351 m/year
+     Temperature min/avg/max: 1521 K, 1600 K, 1679 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |       277s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         1 |      7.17s |       2.6% |
+| Assemble composition system     |         1 |      2.45s |      0.89% |
+| Assemble temperature system     |         1 |      4.04s |       1.5% |
+| Build Stokes preconditioner     |         1 |      7.57s |       2.7% |
+| Build composition preconditioner|         1 |     0.453s |      0.16% |
+| Build temperature preconditioner|         1 |     0.446s |      0.16% |
+| Solve Stokes system             |         1 |       240s |        87% |
+| Solve composition system        |         1 |     0.343s |      0.12% |
+| Solve temperature system        |         1 |     0.674s |      0.24% |
+| Initialization                  |         1 |     0.379s |      0.14% |
+| Postprocessing                  |         1 |     0.578s |      0.21% |
+| Setup dof systems               |         1 |      2.21s |       0.8% |
+| Setup initial conditions        |         1 |      2.12s |      0.77% |
++---------------------------------+-----------+------------+------------+
+
+*** Timestep 1:  t=225495 years
+   Solving temperature system... 13 iterations.
+   Solving C_1 system ... 16 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+10 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.0181 m/year, 0.0351 m/year
+     Temperature min/avg/max: 1521 K, 1600 K, 1679 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |       481s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |      14.9s |       3.1% |
+| Assemble composition system     |         2 |      5.28s |       1.1% |
+| Assemble temperature system     |         2 |      7.98s |       1.7% |
+| Build Stokes preconditioner     |         2 |      13.9s |       2.9% |
+| Build composition preconditioner|         2 |     0.921s |      0.19% |
+| Build temperature preconditioner|         2 |     0.839s |      0.17% |
+| Solve Stokes system             |         2 |       421s |        87% |
+| Solve composition system        |         2 |     0.931s |      0.19% |
+| Solve temperature system        |         2 |      1.18s |      0.25% |
+| Initialization                  |         1 |     0.379s |         0% |
+| Postprocessing                  |         2 |      1.07s |      0.22% |
+| Setup dof systems               |         1 |      2.21s |      0.46% |
+| Setup initial conditions        |         1 |      2.12s |      0.44% |
++---------------------------------+-----------+------------+------------+
+
+Termination requested by criterion: end step
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |       481s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |      14.9s |       3.1% |
+| Assemble composition system     |         2 |      5.28s |       1.1% |
+| Assemble temperature system     |         2 |      7.98s |       1.7% |
+| Build Stokes preconditioner     |         2 |      13.9s |       2.9% |
+| Build composition preconditioner|         2 |     0.921s |      0.19% |
+| Build temperature preconditioner|         2 |     0.839s |      0.17% |
+| Solve Stokes system             |         2 |       421s |        87% |
+| Solve composition system        |         2 |     0.931s |      0.19% |
+| Solve temperature system        |         2 |      1.18s |      0.25% |
+| Initialization                  |         1 |     0.379s |         0% |
+| Postprocessing                  |         2 |      1.07s |      0.22% |
+| Setup dof systems               |         1 |      2.21s |      0.46% |
+| Setup initial conditions        |         1 |      2.12s |      0.44% |
++---------------------------------+-----------+------------+------------+
+

--- a/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_6_2_1
+++ b/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_6_2_1
@@ -1,0 +1,100 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 2.0.0-pre (master, 7a539e8)
+--     . using deal.II 8.5.1 (v8.5.1, 0e5d7e8)
+--     . using Trilinos 12.10.1
+--     . using p4est 1.1.0
+--     . running in OPTIMIZED mode
+--     . running with 6 MPI processes
+-----------------------------------------------------------------------------
+
+Number of active cells: 6,144 (on 3 levels)
+Number of degrees of freedom: 268,220 (156,774+6,930+52,258+52,258)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+24 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.0181 m/year, 0.0426 m/year
+     Temperature min/avg/max: 1522 K, 1600 K, 1678 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      13.5s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         1 |      1.31s |       9.7% |
+| Assemble composition system     |         1 |      0.38s |       2.8% |
+| Assemble temperature system     |         1 |     0.623s |       4.6% |
+| Build Stokes preconditioner     |         1 |     0.923s |       6.8% |
+| Build composition preconditioner|         1 |    0.0635s |      0.47% |
+| Build temperature preconditioner|         1 |    0.0859s |      0.63% |
+| Solve Stokes system             |         1 |      8.68s |        64% |
+| Solve composition system        |         1 |   0.00807s |         0% |
+| Solve temperature system        |         1 |    0.0377s |      0.28% |
+| Initialization                  |         1 |     0.195s |       1.4% |
+| Postprocessing                  |         1 |    0.0799s |      0.59% |
+| Setup dof systems               |         1 |     0.275s |         2% |
+| Setup initial conditions        |         1 |     0.128s |      0.95% |
++---------------------------------+-----------+------------+------------+
+
+*** Timestep 1:  t=2.25401e+06 years
+   Solving temperature system... 13 iterations.
+   Solving C_1 system ... 15 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+22 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.018 m/year, 0.0423 m/year
+     Temperature min/avg/max: 1523 K, 1600 K, 1678 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |        30s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |      2.68s |       8.9% |
+| Assemble composition system     |         2 |     0.825s |       2.7% |
+| Assemble temperature system     |         2 |      1.28s |       4.3% |
+| Build Stokes preconditioner     |         2 |      1.82s |       6.1% |
+| Build composition preconditioner|         2 |     0.126s |      0.42% |
+| Build temperature preconditioner|         2 |      0.15s |       0.5% |
+| Solve Stokes system             |         2 |      21.4s |        71% |
+| Solve composition system        |         2 |     0.042s |      0.14% |
+| Solve temperature system        |         2 |    0.0674s |      0.22% |
+| Initialization                  |         1 |     0.195s |      0.65% |
+| Postprocessing                  |         2 |     0.152s |      0.51% |
+| Setup dof systems               |         1 |     0.275s |      0.92% |
+| Setup initial conditions        |         1 |     0.128s |      0.43% |
++---------------------------------+-----------+------------+------------+
+
+Termination requested by criterion: end step
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |        30s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |      2.68s |       8.9% |
+| Assemble composition system     |         2 |     0.825s |       2.7% |
+| Assemble temperature system     |         2 |      1.28s |       4.3% |
+| Build Stokes preconditioner     |         2 |      1.82s |       6.1% |
+| Build composition preconditioner|         2 |     0.126s |      0.42% |
+| Build temperature preconditioner|         2 |      0.15s |       0.5% |
+| Solve Stokes system             |         2 |      21.4s |        71% |
+| Solve composition system        |         2 |     0.042s |      0.14% |
+| Solve temperature system        |         2 |    0.0674s |      0.22% |
+| Initialization                  |         1 |     0.195s |      0.65% |
+| Postprocessing                  |         2 |     0.152s |      0.51% |
+| Setup dof systems               |         1 |     0.275s |      0.92% |
+| Setup initial conditions        |         1 |     0.128s |      0.43% |
++---------------------------------+-----------+------------+------------+
+

--- a/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_6_3_1
+++ b/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_6_3_1
@@ -1,0 +1,100 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 2.0.0-pre (master, 7a539e8)
+--     . using deal.II 8.5.1 (v8.5.1, 0e5d7e8)
+--     . using Trilinos 12.10.1
+--     . using p4est 1.1.0
+--     . running in OPTIMIZED mode
+--     . running with 6 MPI processes
+-----------------------------------------------------------------------------
+
+Number of active cells: 49,152 (on 4 levels)
+Number of degrees of freedom: 2,080,108 (1,216,710+52,258+405,570+405,570)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+26 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.0181 m/year, 0.0355 m/year
+     Temperature min/avg/max: 1521 K, 1600 K, 1679 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |       119s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         1 |        10s |       8.4% |
+| Assemble composition system     |         1 |      2.78s |       2.3% |
+| Assemble temperature system     |         1 |      4.46s |       3.7% |
+| Build Stokes preconditioner     |         1 |      6.71s |       5.6% |
+| Build composition preconditioner|         1 |     0.531s |      0.44% |
+| Build temperature preconditioner|         1 |     0.558s |      0.47% |
+| Solve Stokes system             |         1 |      87.2s |        73% |
+| Solve composition system        |         1 |    0.0553s |         0% |
+| Solve temperature system        |         1 |    0.0883s |         0% |
+| Initialization                  |         1 |     0.182s |      0.15% |
+| Postprocessing                  |         1 |     0.661s |      0.55% |
+| Setup dof systems               |         1 |     0.935s |      0.78% |
+| Setup initial conditions        |         1 |     0.702s |      0.59% |
++---------------------------------+-----------+------------+------------+
+
+*** Timestep 1:  t=1.73604e+06 years
+   Solving temperature system... 13 iterations.
+   Solving C_1 system ... 15 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+24 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.018 m/year, 0.0351 m/year
+     Temperature min/avg/max: 1522 K, 1600 K, 1678 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |       293s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |      20.6s |         7% |
+| Assemble composition system     |         2 |      6.18s |       2.1% |
+| Assemble temperature system     |         2 |      9.44s |       3.2% |
+| Build Stokes preconditioner     |         2 |      13.6s |       4.7% |
+| Build composition preconditioner|         2 |      1.06s |      0.36% |
+| Build temperature preconditioner|         2 |       1.1s |      0.38% |
+| Solve Stokes system             |         2 |       232s |        79% |
+| Solve composition system        |         2 |     0.325s |      0.11% |
+| Solve temperature system        |         2 |     0.337s |      0.11% |
+| Initialization                  |         1 |     0.182s |         0% |
+| Postprocessing                  |         2 |       1.2s |      0.41% |
+| Setup dof systems               |         1 |     0.935s |      0.32% |
+| Setup initial conditions        |         1 |     0.702s |      0.24% |
++---------------------------------+-----------+------------+------------+
+
+Termination requested by criterion: end step
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |       293s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |      20.6s |         7% |
+| Assemble composition system     |         2 |      6.18s |       2.1% |
+| Assemble temperature system     |         2 |      9.44s |       3.2% |
+| Build Stokes preconditioner     |         2 |      13.6s |       4.7% |
+| Build composition preconditioner|         2 |      1.06s |      0.36% |
+| Build temperature preconditioner|         2 |       1.1s |      0.38% |
+| Solve Stokes system             |         2 |       232s |        79% |
+| Solve composition system        |         2 |     0.325s |      0.11% |
+| Solve temperature system        |         2 |     0.337s |      0.11% |
+| Initialization                  |         1 |     0.182s |         0% |
+| Postprocessing                  |         2 |       1.2s |      0.41% |
+| Setup dof systems               |         1 |     0.935s |      0.32% |
+| Setup initial conditions        |         1 |     0.702s |      0.24% |
++---------------------------------+-----------+------------+------------+
+

--- a/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_768_3_1
+++ b/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_768_3_1
@@ -1,0 +1,100 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 2.0.0-pre (master, 7a539e8)
+--     . using deal.II 8.5.1 (v8.5.1, 0e5d7e8)
+--     . using Trilinos 12.10.1
+--     . using p4est 1.1.0
+--     . running in OPTIMIZED mode
+--     . running with 768 MPI processes
+-----------------------------------------------------------------------------
+
+Number of active cells: 49,152 (on 4 levels)
+Number of degrees of freedom: 2,080,108 (1,216,710+52,258+405,570+405,570)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+27 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.0181 m/year, 0.0355 m/year
+     Temperature min/avg/max: 1521 K, 1600 K, 1679 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      10.2s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         1 |     0.194s |       1.9% |
+| Assemble composition system     |         1 |    0.0988s |      0.97% |
+| Assemble temperature system     |         1 |     0.186s |       1.8% |
+| Build Stokes preconditioner     |         1 |     0.586s |       5.7% |
+| Build composition preconditioner|         1 |     0.027s |      0.26% |
+| Build temperature preconditioner|         1 |    0.0503s |      0.49% |
+| Solve Stokes system             |         1 |      7.48s |        73% |
+| Solve composition system        |         1 |    0.0203s |       0.2% |
+| Solve temperature system        |         1 |    0.0947s |      0.93% |
+| Initialization                  |         1 |     0.234s |       2.3% |
+| Postprocessing                  |         1 |    0.0258s |      0.25% |
+| Setup dof systems               |         1 |     0.279s |       2.7% |
+| Setup initial conditions        |         1 |     0.248s |       2.4% |
++---------------------------------+-----------+------------+------------+
+
+*** Timestep 1:  t=1.73464e+06 years
+   Solving temperature system... 16 iterations.
+   Solving C_1 system ... 19 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+24 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.0181 m/year, 0.0356 m/year
+     Temperature min/avg/max: 1522 K, 1600 K, 1678 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      22.9s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |     0.403s |       1.8% |
+| Assemble composition system     |         2 |     0.168s |      0.74% |
+| Assemble temperature system     |         2 |     0.279s |       1.2% |
+| Build Stokes preconditioner     |         2 |     0.825s |       3.6% |
+| Build composition preconditioner|         2 |    0.0422s |      0.18% |
+| Build temperature preconditioner|         2 |    0.0555s |      0.24% |
+| Solve Stokes system             |         2 |      19.5s |        85% |
+| Solve composition system        |         2 |    0.0524s |      0.23% |
+| Solve temperature system        |         2 |     0.118s |      0.52% |
+| Initialization                  |         1 |     0.234s |         1% |
+| Postprocessing                  |         2 |    0.0358s |      0.16% |
+| Setup dof systems               |         1 |     0.279s |       1.2% |
+| Setup initial conditions        |         1 |     0.248s |       1.1% |
++---------------------------------+-----------+------------+------------+
+
+Termination requested by criterion: end step
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      22.9s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |     0.403s |       1.8% |
+| Assemble composition system     |         2 |     0.168s |      0.74% |
+| Assemble temperature system     |         2 |     0.279s |       1.2% |
+| Build Stokes preconditioner     |         2 |     0.825s |       3.6% |
+| Build composition preconditioner|         2 |    0.0422s |      0.18% |
+| Build temperature preconditioner|         2 |    0.0555s |      0.24% |
+| Solve Stokes system             |         2 |      19.5s |        85% |
+| Solve composition system        |         2 |    0.0524s |      0.23% |
+| Solve temperature system        |         2 |     0.118s |      0.52% |
+| Initialization                  |         1 |     0.234s |         1% |
+| Postprocessing                  |         2 |    0.0358s |      0.16% |
+| Setup dof systems               |         1 |     0.279s |       1.2% |
+| Setup initial conditions        |         1 |     0.248s |       1.1% |
++---------------------------------+-----------+------------+------------+
+

--- a/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_768_4_1
+++ b/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_768_4_1
@@ -1,0 +1,100 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 2.0.0-pre (master, 7a539e8)
+--     . using deal.II 8.5.1 (v8.5.1, 0e5d7e8)
+--     . using Trilinos 12.10.1
+--     . using p4est 1.1.0
+--     . running in OPTIMIZED mode
+--     . running with 768 MPI processes
+-----------------------------------------------------------------------------
+
+Number of active cells: 393,216 (on 5 levels)
+Number of degrees of freedom: 16,380,620 (9,585,030+405,570+3,195,010+3,195,010)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+13 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.0181 m/year, 0.0352 m/year
+     Temperature min/avg/max: 1521 K, 1600 K, 1679 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      17.8s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         1 |     0.994s |       5.6% |
+| Assemble composition system     |         1 |     0.368s |       2.1% |
+| Assemble temperature system     |         1 |     0.576s |       3.2% |
+| Build Stokes preconditioner     |         1 |      3.88s |        22% |
+| Build composition preconditioner|         1 |    0.0909s |      0.51% |
+| Build temperature preconditioner|         1 |     0.127s |      0.71% |
+| Solve Stokes system             |         1 |      9.36s |        53% |
+| Solve composition system        |         1 |     0.105s |      0.59% |
+| Solve temperature system        |         1 |    0.0931s |      0.52% |
+| Initialization                  |         1 |     0.225s |       1.3% |
+| Postprocessing                  |         1 |    0.0739s |      0.42% |
+| Setup dof systems               |         1 |     0.391s |       2.2% |
+| Setup initial conditions        |         1 |     0.296s |       1.7% |
++---------------------------------+-----------+------------+------------+
+
+*** Timestep 1:  t=899787 years
+   Solving temperature system... 15 iterations.
+   Solving C_1 system ... 17 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+26 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.0181 m/year, 0.0352 m/year
+     Temperature min/avg/max: 1521 K, 1600 K, 1679 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      52.2s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |         2s |       3.8% |
+| Assemble composition system     |         2 |     0.741s |       1.4% |
+| Assemble temperature system     |         2 |      1.11s |       2.1% |
+| Build Stokes preconditioner     |         2 |      8.05s |        15% |
+| Build composition preconditioner|         2 |     0.152s |      0.29% |
+| Build temperature preconditioner|         2 |     0.168s |      0.32% |
+| Solve Stokes system             |         2 |      37.4s |        72% |
+| Solve composition system        |         2 |     0.166s |      0.32% |
+| Solve temperature system        |         2 |     0.152s |      0.29% |
+| Initialization                  |         1 |     0.225s |      0.43% |
+| Postprocessing                  |         2 |     0.161s |      0.31% |
+| Setup dof systems               |         1 |     0.391s |      0.75% |
+| Setup initial conditions        |         1 |     0.296s |      0.57% |
++---------------------------------+-----------+------------+------------+
+
+Termination requested by criterion: end step
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      52.2s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |         2s |       3.8% |
+| Assemble composition system     |         2 |     0.741s |       1.4% |
+| Assemble temperature system     |         2 |      1.11s |       2.1% |
+| Build Stokes preconditioner     |         2 |      8.05s |        15% |
+| Build composition preconditioner|         2 |     0.152s |      0.29% |
+| Build temperature preconditioner|         2 |     0.168s |      0.32% |
+| Solve Stokes system             |         2 |      37.4s |        72% |
+| Solve composition system        |         2 |     0.166s |      0.32% |
+| Solve temperature system        |         2 |     0.152s |      0.29% |
+| Initialization                  |         1 |     0.225s |      0.43% |
+| Postprocessing                  |         2 |     0.161s |      0.31% |
+| Setup dof systems               |         1 |     0.391s |      0.75% |
+| Setup initial conditions        |         1 |     0.296s |      0.57% |
++---------------------------------+-----------+------------+------------+
+

--- a/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_768_5_1
+++ b/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_768_5_1
@@ -1,0 +1,100 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 2.0.0-pre (master, 7a539e8)
+--     . using deal.II 8.5.1 (v8.5.1, 0e5d7e8)
+--     . using Trilinos 12.10.1
+--     . using p4est 1.1.0
+--     . running in OPTIMIZED mode
+--     . running with 768 MPI processes
+-----------------------------------------------------------------------------
+
+Number of active cells: 3,145,728 (on 6 levels)
+Number of degrees of freedom: 130,008,460 (76,088,070+3,195,010+25,362,690+25,362,690)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+13 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.0181 m/year, 0.0352 m/year
+     Temperature min/avg/max: 1521 K, 1600 K, 1679 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      97.1s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         1 |      6.81s |         7% |
+| Assemble composition system     |         1 |      2.23s |       2.3% |
+| Assemble temperature system     |         1 |      3.24s |       3.3% |
+| Build Stokes preconditioner     |         1 |      5.51s |       5.7% |
+| Build composition preconditioner|         1 |     0.403s |      0.41% |
+| Build temperature preconditioner|         1 |     0.434s |      0.45% |
+| Solve Stokes system             |         1 |      70.1s |        72% |
+| Solve composition system        |         1 |     0.141s |      0.14% |
+| Solve temperature system        |         1 |     0.213s |      0.22% |
+| Initialization                  |         1 |     0.237s |      0.24% |
+| Postprocessing                  |         1 |     0.425s |      0.44% |
+| Setup dof systems               |         1 |      1.11s |       1.1% |
+| Setup initial conditions        |         1 |     0.878s |       0.9% |
++---------------------------------+-----------+------------+------------+
+
+*** Timestep 1:  t=449552 years
+   Solving temperature system... 13 iterations.
+   Solving C_1 system ... 16 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+28 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.0182 m/year, 0.0371 m/year
+     Temperature min/avg/max: 1521 K, 1600 K, 1679 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |       348s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |      14.1s |         4% |
+| Assemble composition system     |         2 |      4.75s |       1.4% |
+| Assemble temperature system     |         2 |      6.93s |         2% |
+| Build Stokes preconditioner     |         2 |        11s |       3.2% |
+| Build composition preconditioner|         2 |     0.758s |      0.22% |
+| Build temperature preconditioner|         2 |     0.855s |      0.25% |
+| Solve Stokes system             |         2 |       300s |        86% |
+| Solve composition system        |         2 |     0.558s |      0.16% |
+| Solve temperature system        |         2 |     0.549s |      0.16% |
+| Initialization                  |         1 |     0.237s |         0% |
+| Postprocessing                  |         2 |      0.83s |      0.24% |
+| Setup dof systems               |         1 |      1.11s |      0.32% |
+| Setup initial conditions        |         1 |     0.878s |      0.25% |
++---------------------------------+-----------+------------+------------+
+
+Termination requested by criterion: end step
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |       348s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |      14.1s |         4% |
+| Assemble composition system     |         2 |      4.75s |       1.4% |
+| Assemble temperature system     |         2 |      6.93s |         2% |
+| Build Stokes preconditioner     |         2 |        11s |       3.2% |
+| Build composition preconditioner|         2 |     0.758s |      0.22% |
+| Build temperature preconditioner|         2 |     0.855s |      0.25% |
+| Solve Stokes system             |         2 |       300s |        86% |
+| Solve composition system        |         2 |     0.558s |      0.16% |
+| Solve temperature system        |         2 |     0.549s |      0.16% |
+| Initialization                  |         1 |     0.237s |         0% |
+| Postprocessing                  |         2 |      0.83s |      0.24% |
+| Setup dof systems               |         1 |      1.11s |      0.32% |
+| Setup initial conditions        |         1 |     0.878s |      0.25% |
++---------------------------------+-----------+------------+------------+
+

--- a/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_96_2_1
+++ b/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_96_2_1
@@ -1,0 +1,100 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 2.0.0-pre (master, 7a539e8)
+--     . using deal.II 8.5.1 (v8.5.1, 0e5d7e8)
+--     . using Trilinos 12.10.1
+--     . using p4est 1.1.0
+--     . running in OPTIMIZED mode
+--     . running with 96 MPI processes
+-----------------------------------------------------------------------------
+
+Number of active cells: 6,144 (on 3 levels)
+Number of degrees of freedom: 268,220 (156,774+6,930+52,258+52,258)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+24 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.0181 m/year, 0.0426 m/year
+     Temperature min/avg/max: 1522 K, 1600 K, 1678 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      3.51s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         1 |     0.146s |       4.2% |
+| Assemble composition system     |         1 |    0.0549s |       1.6% |
+| Assemble temperature system     |         1 |     0.108s |       3.1% |
+| Build Stokes preconditioner     |         1 |     0.383s |        11% |
+| Build composition preconditioner|         1 |   0.00535s |      0.15% |
+| Build temperature preconditioner|         1 |    0.0481s |       1.4% |
+| Solve Stokes system             |         1 |      1.84s |        53% |
+| Solve composition system        |         1 |   0.00461s |      0.13% |
+| Solve temperature system        |         1 |    0.0516s |       1.5% |
+| Initialization                  |         1 |     0.243s |       6.9% |
+| Postprocessing                  |         1 |    0.0203s |      0.58% |
+| Setup dof systems               |         1 |     0.204s |       5.8% |
+| Setup initial conditions        |         1 |    0.0829s |       2.4% |
++---------------------------------+-----------+------------+------------+
+
+*** Timestep 1:  t=2.25291e+06 years
+   Solving temperature system... 16 iterations.
+   Solving C_1 system ... 18 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+22 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.018 m/year, 0.0423 m/year
+     Temperature min/avg/max: 1523 K, 1600 K, 1678 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      6.62s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |     0.315s |       4.8% |
+| Assemble composition system     |         2 |     0.113s |       1.7% |
+| Assemble temperature system     |         2 |     0.192s |       2.9% |
+| Build Stokes preconditioner     |         2 |     0.538s |       8.1% |
+| Build composition preconditioner|         2 |     0.018s |      0.27% |
+| Build temperature preconditioner|         2 |    0.0684s |         1% |
+| Solve Stokes system             |         2 |      4.41s |        67% |
+| Solve composition system        |         2 |    0.0279s |      0.42% |
+| Solve temperature system        |         2 |    0.0611s |      0.92% |
+| Initialization                  |         1 |     0.243s |       3.7% |
+| Postprocessing                  |         2 |    0.0288s |      0.44% |
+| Setup dof systems               |         1 |     0.204s |       3.1% |
+| Setup initial conditions        |         1 |    0.0829s |       1.3% |
++---------------------------------+-----------+------------+------------+
+
+Termination requested by criterion: end step
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      6.62s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |     0.315s |       4.8% |
+| Assemble composition system     |         2 |     0.113s |       1.7% |
+| Assemble temperature system     |         2 |     0.192s |       2.9% |
+| Build Stokes preconditioner     |         2 |     0.538s |       8.1% |
+| Build composition preconditioner|         2 |     0.018s |      0.27% |
+| Build temperature preconditioner|         2 |    0.0684s |         1% |
+| Solve Stokes system             |         2 |      4.41s |        67% |
+| Solve composition system        |         2 |    0.0279s |      0.42% |
+| Solve temperature system        |         2 |    0.0611s |      0.92% |
+| Initialization                  |         1 |     0.243s |       3.7% |
+| Postprocessing                  |         2 |    0.0288s |      0.44% |
+| Setup dof systems               |         1 |     0.204s |       3.1% |
+| Setup initial conditions        |         1 |    0.0829s |       1.3% |
++---------------------------------+-----------+------------+------------+
+

--- a/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_96_3_1
+++ b/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_96_3_1
@@ -1,0 +1,100 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 2.0.0-pre (master, 7a539e8)
+--     . using deal.II 8.5.1 (v8.5.1, 0e5d7e8)
+--     . using Trilinos 12.10.1
+--     . using p4est 1.1.0
+--     . running in OPTIMIZED mode
+--     . running with 96 MPI processes
+-----------------------------------------------------------------------------
+
+Number of active cells: 49,152 (on 4 levels)
+Number of degrees of freedom: 2,080,108 (1,216,710+52,258+405,570+405,570)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+26 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.0181 m/year, 0.0355 m/year
+     Temperature min/avg/max: 1521 K, 1600 K, 1679 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      17.2s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         1 |     0.893s |       5.2% |
+| Assemble composition system     |         1 |     0.302s |       1.8% |
+| Assemble temperature system     |         1 |     0.486s |       2.8% |
+| Build Stokes preconditioner     |         1 |     0.866s |         5% |
+| Build composition preconditioner|         1 |     0.041s |      0.24% |
+| Build temperature preconditioner|         1 |    0.0888s |      0.52% |
+| Solve Stokes system             |         1 |      12.9s |        75% |
+| Solve composition system        |         1 |    0.0107s |         0% |
+| Solve temperature system        |         1 |    0.0607s |      0.35% |
+| Initialization                  |         1 |     0.246s |       1.4% |
+| Postprocessing                  |         1 |    0.0558s |      0.32% |
+| Setup dof systems               |         1 |     0.326s |       1.9% |
+| Setup initial conditions        |         1 |     0.143s |      0.83% |
++---------------------------------+-----------+------------+------------+
+
+*** Timestep 1:  t=1.73331e+06 years
+   Solving temperature system... 16 iterations.
+   Solving C_1 system ... 18 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+24 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.018 m/year, 0.0352 m/year
+     Temperature min/avg/max: 1522 K, 1600 K, 1678 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      40.3s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |      1.82s |       4.5% |
+| Assemble composition system     |         2 |     0.609s |       1.5% |
+| Assemble temperature system     |         2 |     0.969s |       2.4% |
+| Build Stokes preconditioner     |         2 |      1.55s |       3.8% |
+| Build composition preconditioner|         2 |    0.0817s |       0.2% |
+| Build temperature preconditioner|         2 |      0.13s |      0.32% |
+| Solve Stokes system             |         2 |      33.3s |        83% |
+| Solve composition system        |         2 |    0.0616s |      0.15% |
+| Solve temperature system        |         2 |     0.101s |      0.25% |
+| Initialization                  |         1 |     0.246s |      0.61% |
+| Postprocessing                  |         2 |     0.104s |      0.26% |
+| Setup dof systems               |         1 |     0.326s |      0.81% |
+| Setup initial conditions        |         1 |     0.143s |      0.35% |
++---------------------------------+-----------+------------+------------+
+
+Termination requested by criterion: end step
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      40.3s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |      1.82s |       4.5% |
+| Assemble composition system     |         2 |     0.609s |       1.5% |
+| Assemble temperature system     |         2 |     0.969s |       2.4% |
+| Build Stokes preconditioner     |         2 |      1.55s |       3.8% |
+| Build composition preconditioner|         2 |    0.0817s |       0.2% |
+| Build temperature preconditioner|         2 |      0.13s |      0.32% |
+| Solve Stokes system             |         2 |      33.3s |        83% |
+| Solve composition system        |         2 |    0.0616s |      0.15% |
+| Solve temperature system        |         2 |     0.101s |      0.25% |
+| Initialization                  |         1 |     0.246s |      0.61% |
+| Postprocessing                  |         2 |     0.104s |      0.26% |
+| Setup dof systems               |         1 |     0.326s |      0.81% |
+| Setup initial conditions        |         1 |     0.143s |      0.35% |
++---------------------------------+-----------+------------+------------+
+

--- a/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_96_4_1
+++ b/results/spherical_shell_expensive_solver/Stampede2_TACC_aspect_2.0-pre/output_96_4_1
@@ -1,0 +1,100 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 2.0.0-pre (master, 7a539e8)
+--     . using deal.II 8.5.1 (v8.5.1, 0e5d7e8)
+--     . using Trilinos 12.10.1
+--     . using p4est 1.1.0
+--     . running in OPTIMIZED mode
+--     . running with 96 MPI processes
+-----------------------------------------------------------------------------
+
+Number of active cells: 393,216 (on 5 levels)
+Number of degrees of freedom: 16,380,620 (9,585,030+405,570+3,195,010+3,195,010)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+13 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.0181 m/year, 0.0352 m/year
+     Temperature min/avg/max: 1521 K, 1600 K, 1679 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      57.9s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         1 |      6.59s |        11% |
+| Assemble composition system     |         1 |      1.98s |       3.4% |
+| Assemble temperature system     |         1 |      3.01s |       5.2% |
+| Build Stokes preconditioner     |         1 |      4.71s |       8.1% |
+| Build composition preconditioner|         1 |     0.356s |      0.62% |
+| Build temperature preconditioner|         1 |     0.388s |      0.67% |
+| Solve Stokes system             |         1 |      34.8s |        60% |
+| Solve composition system        |         1 |    0.0526s |         0% |
+| Solve temperature system        |         1 |     0.104s |      0.18% |
+| Initialization                  |         1 |     0.259s |      0.45% |
+| Postprocessing                  |         1 |     0.364s |      0.63% |
+| Setup dof systems               |         1 |     0.911s |       1.6% |
+| Setup initial conditions        |         1 |      0.53s |      0.91% |
++---------------------------------+-----------+------------+------------+
+
+*** Timestep 1:  t=899723 years
+   Solving temperature system... 14 iterations.
+   Solving C_1 system ... 17 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+26 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.0181 m/year, 0.035 m/year
+     Temperature min/avg/max: 1521 K, 1600 K, 1679 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |       185s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |      13.6s |       7.3% |
+| Assemble composition system     |         2 |      4.27s |       2.3% |
+| Assemble temperature system     |         2 |      6.35s |       3.4% |
+| Build Stokes preconditioner     |         2 |      9.42s |       5.1% |
+| Build composition preconditioner|         2 |     0.709s |      0.38% |
+| Build temperature preconditioner|         2 |     0.747s |       0.4% |
+| Solve Stokes system             |         2 |       142s |        77% |
+| Solve composition system        |         2 |     0.353s |      0.19% |
+| Solve temperature system        |         2 |     0.361s |       0.2% |
+| Initialization                  |         1 |     0.259s |      0.14% |
+| Postprocessing                  |         2 |     0.705s |      0.38% |
+| Setup dof systems               |         1 |     0.911s |      0.49% |
+| Setup initial conditions        |         1 |      0.53s |      0.29% |
++---------------------------------+-----------+------------+------------+
+
+Termination requested by criterion: end step
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |       185s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |      13.6s |       7.3% |
+| Assemble composition system     |         2 |      4.27s |       2.3% |
+| Assemble temperature system     |         2 |      6.35s |       3.4% |
+| Build Stokes preconditioner     |         2 |      9.42s |       5.1% |
+| Build composition preconditioner|         2 |     0.709s |      0.38% |
+| Build temperature preconditioner|         2 |     0.747s |       0.4% |
+| Solve Stokes system             |         2 |       142s |        77% |
+| Solve composition system        |         2 |     0.353s |      0.19% |
+| Solve temperature system        |         2 |     0.361s |       0.2% |
+| Initialization                  |         1 |     0.259s |      0.14% |
+| Postprocessing                  |         2 |     0.705s |      0.38% |
+| Setup dof systems               |         1 |     0.911s |      0.49% |
+| Setup initial conditions        |         1 |      0.53s |      0.29% |
++---------------------------------+-----------+------------+------------+
+


### PR DESCRIPTION
Results for the Skylake nodes on Stampede2. The KNL nodes shower fairly poor results early on, but I can try running a full set of scaling results on those as well. However, the Skylake nodes have significantly more memory per core available, so really not much motivation to use the KNL nodes.

